### PR TITLE
'Bad substitution' error from ${BASH_SOURCE[0]}

### DIFF
--- a/osmesa-install.sh
+++ b/osmesa-install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # environment variables used by this script:
 # - OSMESA_PREFIX: where to install osmesa (must be writable)


### PR DESCRIPTION
You will get a 'Bad substitution' error on the following 2 lines running the script
in Linux (e.g. Ubuntu 16.04), change `#!/bin/sh` on the first line to` #!/bin/bash`.
-ln 49 `scriptdir=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)`
-ln 50 `scriptname=$(basename ${BASH_SOURCE[0]} .sh)`
This issue is because, bin/sh is a syslink to /bin/dash which does not support `${array[0]}` .
There are several solutions, I have chosen to use bash explicitly.

I've made several updates to my master branch which prevent it from automatically merging with yours so I created a patch with just this fix. If you are interested in the updates on master, let me know and I'll create a pull request. The main enhancement allows you to confirm your options before executing.

Cheers,