### PR TITLE
LLVM-add-ORC-patch

### DIFF
--- a/osmesa-install.sh
+++ b/osmesa-install.sh
@@ -287,6 +287,12 @@ if [ "$osmesadriver" = 3 ] || [ "$osmesadriver" = 4 ]; then
                      llvm_patches="msys2_add_pi.patch"
                      ;;
             esac
+
+            # Apply ORC patch on LLVM 4.x and 5.x
+            if [ ${llvmversion:0:2} = 4. ] || [ ${llvmversion:0:2} = 5. ]; then
+                llvm_patches="0001-Fix-return-type-in-ORC-readMem-client-interface.patch :$llvm_patches"
+            fi
+
             for i in $llvm_patches; do
                 if [ -f "$srcdir"/patches/llvm-$llvmversion/$i ]; then
                     echo "* applying patch $i"

--- a/patches/llvm-4.0.1/0001-Fix-return-type-in-ORC-readMem-client-interface.patch
+++ b/patches/llvm-4.0.1/0001-Fix-return-type-in-ORC-readMem-client-interface.patch
@@ -1,0 +1,31 @@
+From 5cea35478aaaac7728a50cbafd3770f96162f7ac Mon Sep 17 00:00:00 2001
+From: Tilmann Scheller <tschelle@redhat.com>
+Date: Thu, 1 Feb 2018 11:40:01 -0600
+Subject: [PATCH] Fix return type in ORC readMem() client interface.
+
+GCC 8.0.1 detects the type mismatch and causes the compilation to fail. Clang
+and earlier versions of GCC don't detect the issue.
+
+Fixes rhbz#1540620.
+---
+ include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h b/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+index da02250ba16..bed472e2e0e 100644
+--- a/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
++++ b/include/llvm/ExecutionEngine/Orc/OrcRemoteTargetClient.h
+@@ -713,8 +713,8 @@ private:
+ 
+   uint32_t getTrampolineSize() const { return RemoteTrampolineSize; }
+ 
+-  Expected<std::vector<char>> readMem(char *Dst, JITTargetAddress Src,
+-                                      uint64_t Size) {
++  Expected<std::vector<uint8_t>> readMem(char *Dst, JITTargetAddress Src,
++                                         uint64_t Size) {
+     // Check for an 'out-of-band' error, e.g. from an MM destructor.
+     if (ExistingError)
+       return std::move(ExistingError);
+-- 
+2.16.1
+


### PR DESCRIPTION
LLVM 4.0.1 and 5.0.0 do not build with GCC 8.x due to bug 1540620 described here:

https://bugzilla.redhat.com/show_bug.cgi?id=1540620

This patch fixes the issue.