### PR TITLE
support scons 3.1 (using python 3.9) on MSYS2/MinGW

### DIFF
--- a/osmesa-install.sh
+++ b/osmesa-install.sh
@@ -454,9 +454,15 @@ if [ "$mangled" = 1 ]; then
 fi
 
 # mingw-specific patches (for maintainability, prefer putting everything in the main patch list)
-#if [ "$osname" = "Msys" ] || [ "$osname" = "MINGW64_NT-6.1" ] || [ "$osname" = "MINGW32_NT-6.1" ]; then
-#    PATCHES="$PATCHES "
-#fi
+mingw=0
+case "$osname" in
+    Msys*|MSYS*|MINGW*)
+    mingw=1
+    ;;
+esac
+if [ "$mingw" = 1 ]; then
+    PATCHES="$PATCHES scons31-python39-001.patch scons31-python39-002.patch"
+fi
 
 if [ "$osname" = Darwin ]; then
     # patches for Mesa 12.0.1 from

--- a/patches/mesa-17.1.10/scons31-python39-001.patch
+++ b/patches/mesa-17.1.10/scons31-python39-001.patch
@@ -1,0 +1,230 @@
+--- a/SConstruct
++++ b/SConstruct
+@@ -152,8 +152,7 @@ try:
+ except ImportError:
+     pass
+ else:
+-    aliases = default_ans.keys()
+-    aliases.sort()
++    aliases = sorted(default_ans.keys())
+     env.Help('\n')
+     env.Help('Recognized targets:\n')
+     for alias in aliases:
+diff --git a/SConstruct b/SConstruct
+index 696718c8eb4..0215aa83073 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -50,10 +50,10 @@ except KeyError:
+     pass
+ else:
+     targets = targets.split(',')
+-    print 'scons: warning: targets option is deprecated; pass the targets on their own such as'
+-    print
+-    print '  scons %s' % ' '.join(targets)
+-    print
++    print('scons: warning: targets option is deprecated; pass the targets on their own such as')
++    print()
++    print('  scons %s' % ' '.join(targets))
++    print()
+     COMMAND_LINE_TARGETS.append(targets)
+ 
+ 
+diff --git a/src/gallium/drivers/llvmpipe/SConscript b/src/gallium/drivers/llvmpipe/SConscript
+index fbbd22a5299..74d7a9e1673 100644
+--- a/src/gallium/drivers/llvmpipe/SConscript
++++ b/src/gallium/drivers/llvmpipe/SConscript
+@@ -4,7 +4,7 @@ import distutils.version
+ Import('*')
+ 
+ if not env['llvm']:
+-    print 'warning: LLVM disabled: not building llvmpipe'
++    print('warning: LLVM disabled: not building llvmpipe')
+     Return()
+ 
+ env = env.Clone()
+diff --git a/src/gallium/drivers/svga/SConscript b/src/gallium/drivers/svga/SConscript
+index 2d60ceb2be5..9c4806c7158 100644
+--- a/src/gallium/drivers/svga/SConscript
++++ b/src/gallium/drivers/svga/SConscript
+@@ -5,7 +5,7 @@ env = env.Clone()
+ env.MSVC2013Compat()
+ 
+ if env['suncc']:
+-	print 'warning: not building svga'
++	print('warning: not building svga')
+ 	Return()
+ 
+ env.Append(CPPDEFINES = [
+diff --git a/src/gallium/drivers/swr/SConscript b/src/gallium/drivers/swr/SConscript
+index b394cbc17e3..fdced66463c 100644
+--- a/src/gallium/drivers/swr/SConscript
++++ b/src/gallium/drivers/swr/SConscript
+@@ -8,12 +8,12 @@ if not env['swr']:
+     Return()
+ 
+ if not env['llvm']:
+-    print 'warning: LLVM disabled: not building swr'
++    print('warning: LLVM disabled: not building swr')
+     env['swr'] = False
+     Return()
+ 
+ if env['LLVM_VERSION'] < distutils.version.LooseVersion('3.9'):
+-    print "warning: swr requires LLVM >= 3.9: not building swr"
++    print("warning: swr requires LLVM >= 3.9: not building swr")
+     env['swr'] = False
+     Return()
+ 
+@@ -28,7 +28,7 @@ if env['platform'] == 'windows':
+ else:
+     llvm_config = os.environ.get('LLVM_CONFIG', 'llvm-config')
+     llvm_includedir = env.backtick('%s --includedir' % llvm_config).rstrip()
+-    print "llvm include dir %s" % llvm_includedir
++    print("llvm include dir %s" % llvm_includedir)
+ 
+ if not env['msvc'] :
+     env.Append(CCFLAGS = [
+diff --git a/src/gallium/targets/dri/SConscript b/src/gallium/targets/dri/SConscript
+index d7a8cbdca5d..f5c2818d04f 100644
+--- a/src/gallium/targets/dri/SConscript
++++ b/src/gallium/targets/dri/SConscript
+@@ -3,7 +3,7 @@ Import('*')
+ env = drienv.Clone()
+ 
+ if env['suncc']:
+-    print 'warning: not building dri-vmwgfx'
++    print('warning: not building dri-vmwgfx')
+     Return()
+ 
+ env.Append(CPPPATH = [
+--- a/src/SConscript      2021-11-06 13:15:10.398154100 +0100
++++ b/src/SConscript      2021-11-06 13:15:27.175421700 +0100
+@@ -26,7 +26,7 @@
+     try:
+         (commit, foo) = subprocess.Popen(args, stdout=subprocess.PIPE).communicate()
+     except:
+-        print "Warning: exception in write_git_sha1_h_file()"
++        print("Warning: exception in write_git_sha1_h_file()")
+         # git log command didn't work
+         if not os.path.exists(filename):
+             dirname = os.path.dirname(filename)
+--- a/scons/gallium.py
++++ b/scons/gallium.py
+@@ -132,7 +132,7 @@ def check_cc(env, cc, expr, cpp_opt = '-E'):
+     sys.stdout.write('Checking for %s ... ' % cc)
+ 
+     source = tempfile.NamedTemporaryFile(suffix='.c', delete=False)
+-    source.write('#if !(%s)\n#error\n#endif\n' % expr)
++    source.write(('#if !(%s)\n#error\n#endif\n' % expr).encode())
+     source.close()
+ 
+     # sys.stderr.write('%r %s %s\n' % (env['CC'], cpp_opt, source.name));
+--- a/src/mapi/glapi/gen/gl_XML.py   2021-11-06 15:10:09.295762400 +0100
++++ b/src/mapi/glapi/gen/gl_XML.py        2021-11-06 15:11:10.056873300 +0100
+@@ -705,7 +705,7 @@
+
+         parameters = []
+         return_type = "void"
+-        for child in element.getchildren():
++        for child in element:
+             if child.tag == "return":
+                 return_type = child.get( "type", "void" )
+             elif child.tag == "param":
+@@ -735,7 +735,7 @@
+                 if param.is_image():
+                     self.images.append( param )
+
+-        if element.getchildren():
++        if list(element):
+             self.initialized = 1
+             self.entry_point_parameters[name] = parameters
+         else:
+@@ -907,7 +907,7 @@
+
+
+     def process_OpenGLAPI(self, file_name, element):
+-        for child in element.getchildren():
++        for child in element:
+             if child.tag == "category":
+                 self.process_category( child )
+             elif child.tag == "OpenGLAPI":
+@@ -927,7 +927,7 @@
+         [cat_type, key] = classify_category(cat_name, cat_number)
+         self.categories[cat_type][key] = [cat_name, cat_number]
+
+-        for child in cat.getchildren():
++        for child in cat:
+             if child.tag == "function":
+                 func_name = real_function_name( child )
+
+
+--- a/src/mapi/glapi/gen/gl_XML.py   2021-11-06 15:48:11.564583800 +0100
++++ b/mapi/glapi/gen/gl_XML.py        2021-11-06 15:48:57.416514700 +0100
+@@ -317,7 +317,7 @@
+
+     if len(list) == 0: list = ["void"]
+
+-    return string.join(list, ", ")
++    return ",".join(list)
+
+
+ class gl_item(object):
+
+
+--- a/src/mapi/glapi/gen/typeexpr.py 2021-11-06 15:16:08.660980300 +0100
++++ b/src/mapi/glapi/gen/typeexpr.py      2021-11-06 15:18:11.644076000 +0100
+@@ -124,7 +124,7 @@
+
+         # Replace '*' with ' * ' in type_string.  Then, split the string
+         # into tokens, separated by spaces.
+-        tokens = string.split( string.replace( type_string, "*", " * " ) )
++        tokens = type_string.replace( "*", " * " ).split()
+
+         const = 0
+         t = None
+
+--- a/src/gallium/auxiliary/util/u_format_parse.py   2021-11-06 17:06:10.126736600 +0100
++++ b/src/gallium/auxiliary/util/u_format_parse.py        2021-11-06 17:06:28.586891400 +0100
+@@ -69,6 +69,9 @@
+         return s
+
+     def __eq__(self, other):
++        if other is None:
++            return False
++
+         return self.type == other.type and self.norm == other.norm and self.pure == other.pure and self.size == other.size
+
+     def max(self):
+
+--- a/src/gallium/auxiliary/util/u_format_parse.py   2021-11-06 17:19:54.797902700 +0100
++++ b/src/gallium/auxiliary/util/u_format_parse.py        2021-11-06 17:20:31.231904400 +0100
+@@ -79,7 +79,7 @@
+         if self.type == FLOAT:
+             return VERY_LARGE
+         if self.type == FIXED:
+-            return (1 << (self.size/2)) - 1
++            return (1 << (self.size//2)) - 1
+         if self.norm:
+             return 1
+         if self.type == UNSIGNED:
+@@ -93,7 +93,7 @@
+         if self.type == FLOAT:
+             return -VERY_LARGE
+         if self.type == FIXED:
+-            return -(1 << (self.size/2))
++            return -(1 << (self.size//2))
+         if self.type == UNSIGNED:
+             return 0
+         if self.norm:
+
+--- a/src/gallium/auxiliary/util/u_format_pack.py    2021-11-06 17:31:59.016007700 +0100
++++ b/src/gallium/auxiliary/util/u_format_pack.py 2021-11-06 17:32:43.419846800 +0100
+@@ -238,7 +238,7 @@
+             return truncate_mantissa(value, 23)
+         return value
+     if type.type == FIXED:
+-        return int(value * (1 << (type.size/2)))
++        return int(value * (1 << (type.size//2)))
+     if not type.norm:
+         return int(value)
+     if type.type == UNSIGNED:
+

--- a/patches/mesa-17.1.10/scons31-python39-002.patch
+++ b/patches/mesa-17.1.10/scons31-python39-002.patch
@@ -1,0 +1,7274 @@
+--- ./scons/crossmingw.py	(original)
++++ ./scons/crossmingw.py	(refactored)
+@@ -83,7 +83,7 @@
+     no_import_lib = env.get('no_import_lib', 0)
+ 
+     if not dll:
+-        raise SCons.Errors.UserError, "A shared library should have exactly one target with the suffix: %s" % env.subst("$SHLIBSUFFIX")
++        raise SCons.Errors.UserError("A shared library should have exactly one target with the suffix: %s" % env.subst("$SHLIBSUFFIX"))
+     
+     if not no_import_lib and \
+        not env.FindIxes(target, 'LIBPREFIX', 'LIBSUFFIX'):
+--- ./scons/custom.py	(original)
++++ ./scons/custom.py	(refactored)
+@@ -113,7 +113,7 @@
+     finder = modulefinder.ModuleFinder(path=path)
+     finder.run_script(node.abspath)
+     results = []
+-    for name, mod in finder.modules.iteritems():
++    for name, mod in finder.modules.items():
+         if mod.__file__ is None:
+             continue
+         assert os.path.exists(mod.__file__)
+@@ -189,7 +189,7 @@
+     except OSError:
+         return
+     prefix = name + '_'
+-    for flag_name, flag_value in flags.iteritems():
++    for flag_name, flag_value in flags.items():
+         assert '_' not in flag_name
+         env[prefix + flag_name] = flag_value
+ 
+@@ -222,7 +222,7 @@
+             raise Exception('Attempt to use unavailable module %s' % name)
+ 
+         flags = {}
+-        for flag_name, flag_value in env.Dictionary().iteritems():
++        for flag_name, flag_value in env.Dictionary().items():
+             if flag_name.startswith(prefix):
+                 flag_name = flag_name[len(prefix):]
+                 if '_' not in flag_name:
+@@ -257,12 +257,12 @@
+     sym_table = parser.parse(src.abspath)
+ 
+     if names:
+-        if isinstance(names, basestring):
++        if isinstance(names, str):
+             names = [names]
+ 
+         symbols = names
+     else:
+-        symbols = sym_table.keys()
++        symbols = list(sym_table.keys())
+ 
+     # convert the symbol table to source lists
+     src_lists = {}
+--- ./scons/dxsdk.py	(original)
++++ ./scons/dxsdk.py	(refactored)
+@@ -51,7 +51,7 @@
+     elif env['machine'] == 'x86_64':
+         target_cpu = 'x64'
+     else:
+-        raise SCons.Errors.InternalError, "Unsupported target machine"
++        raise SCons.Errors.InternalError("Unsupported target machine")
+ 
+     include_dir = os.path.join(dxsdk_root, 'Include')
+     lib_dir = os.path.join(dxsdk_root, 'Lib', target_cpu)
+--- ./scons/gallium.py	(original)
++++ ./scons/gallium.py	(refactored)
+@@ -182,15 +182,15 @@
+     env.Tool(env['toolchain'])
+ 
+     # Allow override compiler and specify additional flags from environment
+-    if os.environ.has_key('CC'):
++    if 'CC' in os.environ:
+         env['CC'] = os.environ['CC']
+-    if os.environ.has_key('CFLAGS'):
++    if 'CFLAGS' in os.environ:
+         env['CCFLAGS'] += SCons.Util.CLVar(os.environ['CFLAGS'])
+-    if os.environ.has_key('CXX'):
++    if 'CXX' in os.environ:
+         env['CXX'] = os.environ['CXX']
+-    if os.environ.has_key('CXXFLAGS'):
++    if 'CXXFLAGS' in os.environ:
+         env['CXXFLAGS'] += SCons.Util.CLVar(os.environ['CXXFLAGS'])
+-    if os.environ.has_key('LDFLAGS'):
++    if 'LDFLAGS' in os.environ:
+         env['LINKFLAGS'] += SCons.Util.CLVar(os.environ['LDFLAGS'])
+ 
+     # Detect gcc/clang not by executable name, but through pre-defined macros
+@@ -246,16 +246,16 @@
+     # Backwards compatability with the debug= profile= options
+     if env['build'] == 'debug':
+         if not env['debug']:
+-            print 'scons: warning: debug option is deprecated and will be removed eventually; use instead'
+-            print
+-            print ' scons build=release'
+-            print
++            print('scons: warning: debug option is deprecated and will be removed eventually; use instead')
++            print()
++            print(' scons build=release')
++            print()
+             env['build'] = 'release'
+         if env['profile']:
+-            print 'scons: warning: profile option is deprecated and will be removed eventually; use instead'
+-            print
+-            print ' scons build=profile'
+-            print
++            print('scons: warning: profile option is deprecated and will be removed eventually; use instead')
++            print()
++            print(' scons build=profile')
++            print()
+             env['build'] = 'profile'
+     if False:
+         # Enforce SConscripts to use the new build variable
+@@ -289,7 +289,7 @@
+     env['build_dir'] = build_dir
+     env.SConsignFile(os.path.join(build_dir, '.sconsign'))
+     if 'SCONS_CACHE_DIR' in os.environ:
+-        print 'scons: Using build cache in %s.' % (os.environ['SCONS_CACHE_DIR'],)
++        print('scons: Using build cache in %s.' % (os.environ['SCONS_CACHE_DIR'],))
+         env.CacheDir(os.environ['SCONS_CACHE_DIR'])
+     env['CONFIGUREDIR'] = os.path.join(build_dir, 'conf')
+     env['CONFIGURELOG'] = os.path.join(os.path.abspath(build_dir), 'config.log')
+@@ -376,8 +376,8 @@
+     if env['embedded']:
+         cppdefines += ['PIPE_SUBSYSTEM_EMBEDDED']
+     if env['texture_float']:
+-        print 'warning: Floating-point textures enabled.'
+-        print 'warning: Please consult docs/patents.txt with your lawyer before building Mesa.'
++        print('warning: Floating-point textures enabled.')
++        print('warning: Please consult docs/patents.txt with your lawyer before building Mesa.')
+         cppdefines += ['TEXTURE_FLOAT_ENABLED']
+     env.Append(CPPDEFINES = cppdefines)
+ 
+--- ./scons/llvm.py	(original)
++++ ./scons/llvm.py	(refactored)
+@@ -50,7 +50,7 @@
+         llvm_dir = None
+     else:
+         if not os.path.isdir(llvm_dir):
+-            raise SCons.Errors.InternalError, "Specified LLVM directory not found"
++            raise SCons.Errors.InternalError("Specified LLVM directory not found")
+ 
+         if env['debug']:
+             llvm_subdir = 'Debug'
+@@ -61,20 +61,20 @@
+         if not os.path.isdir(llvm_bin_dir):
+             llvm_bin_dir = os.path.join(llvm_dir, 'bin')
+             if not os.path.isdir(llvm_bin_dir):
+-                raise SCons.Errors.InternalError, "LLVM binary directory not found"
++                raise SCons.Errors.InternalError("LLVM binary directory not found")
+ 
+         env.PrependENVPath('PATH', llvm_bin_dir)
+ 
+     if env['platform'] == 'windows':
+         # XXX: There is no llvm-config on Windows, so assume a standard layout
+         if llvm_dir is None:
+-            print 'scons: LLVM environment variable must be specified when building for windows'
++            print('scons: LLVM environment variable must be specified when building for windows')
+             return
+ 
+         # Try to determine the LLVM version from llvm/Config/config.h
+         llvm_config = os.path.join(llvm_dir, 'include/llvm/Config/llvm-config.h')
+         if not os.path.exists(llvm_config):
+-            print 'scons: could not find %s' % llvm_config
++            print('scons: could not find %s' % llvm_config)
+             return
+         llvm_version_major_re = re.compile(r'^#define LLVM_VERSION_MAJOR ([0-9]+)')
+         llvm_version_minor_re = re.compile(r'^#define LLVM_VERSION_MINOR ([0-9]+)')
+@@ -92,10 +92,10 @@
+             llvm_version = distutils.version.LooseVersion('%s.%s' % (llvm_version_major, llvm_version_minor))
+ 
+         if llvm_version is None:
+-            print 'scons: could not determine the LLVM version from %s' % llvm_config
++            print('scons: could not determine the LLVM version from %s' % llvm_config)
+             return
+         if llvm_version < distutils.version.LooseVersion(required_llvm_version):
+-            print 'scons: LLVM version %s found, but %s is required' % (llvm_version, required_llvm_version)
++            print('scons: LLVM version %s found, but %s is required' % (llvm_version, required_llvm_version))
+             return
+ 
+         env.Prepend(CPPPATH = [os.path.join(llvm_dir, 'include')])
+@@ -214,14 +214,14 @@
+     else:
+         llvm_config = os.environ.get('LLVM_CONFIG', 'llvm-config')
+         if not env.Detect(llvm_config):
+-            print 'scons: %s script not found' % llvm_config
++            print('scons: %s script not found' % llvm_config)
+             return
+ 
+         llvm_version = env.backtick('%s --version' % llvm_config).rstrip()
+         llvm_version = distutils.version.LooseVersion(llvm_version)
+ 
+         if llvm_version < distutils.version.LooseVersion(required_llvm_version):
+-            print 'scons: LLVM version %s found, but %s is required' % (llvm_version, required_llvm_version)
++            print('scons: LLVM version %s found, but %s is required' % (llvm_version, required_llvm_version))
+             return
+ 
+         try:
+@@ -247,13 +247,13 @@
+                 env.ParseConfig('%s --system-libs' % llvm_config)
+                 env.Append(CXXFLAGS = ['-std=c++11'])
+         except OSError:
+-            print 'scons: llvm-config version %s failed' % llvm_version
++            print('scons: llvm-config version %s failed' % llvm_version)
+             return
+ 
+     assert llvm_version is not None
+     env['llvm'] = True
+ 
+-    print 'scons: Found LLVM version %s' % llvm_version
++    print('scons: Found LLVM version %s' % llvm_version)
+     env['LLVM_VERSION'] = llvm_version
+ 
+     # Define HAVE_LLVM macro with the major/minor version number (e.g., 0x0206 for 2.6)
+--- ./src/amd/common/sid_tables.py	(original)
++++ ./src/amd/common/sid_tables.py	(refactored)
+@@ -217,10 +217,10 @@
+     strings = StringTable()
+     strings_offsets = IntTable("int")
+ 
+-    print '/* This file is autogenerated by sid_tables.py from sid.h. Do not edit directly. */'
+-    print
+-    print CopyRight.strip()
+-    print '''
++    print('/* This file is autogenerated by sid_tables.py from sid.h. Do not edit directly. */')
++    print()
++    print(CopyRight.strip())
++    print('''
+ #ifndef SID_TABLES_H
+ #define SID_TABLES_H
+ 
+@@ -242,20 +242,20 @@
+         unsigned name_offset;
+         unsigned op;
+ };
+-'''
+-
+-    print 'static const struct si_packet3 packet3_table[] = {'
++''')
++
++    print('static const struct si_packet3 packet3_table[] = {')
+     for pkt in packets:
+-        print '\t{%s, %s},' % (strings.add(pkt[5:]), pkt)
+-    print '};'
+-    print
+-
+-    print 'static const struct si_field sid_fields_table[] = {'
++        print('\t{%s, %s},' % (strings.add(pkt[5:]), pkt))
++    print('};')
++    print()
++
++    print('static const struct si_field sid_fields_table[] = {')
+ 
+     fields_idx = 0
+     for reg in regs:
+         if len(reg.fields) and reg.own_fields:
+-            print '\t/* %s */' % (fields_idx)
++            print('\t/* %s */' % (fields_idx))
+ 
+             reg.fields_idx = fields_idx
+ 
+@@ -266,34 +266,34 @@
+                         while value[1] >= len(values_offsets):
+                             values_offsets.append(-1)
+                         values_offsets[value[1]] = strings.add(strip_prefix(value[0]))
+-                    print '\t{%s, %s(~0u), %s, %s},' % (
++                    print('\t{%s, %s(~0u), %s, %s},' % (
+                         strings.add(field.name), field.s_name,
+-                        len(values_offsets), strings_offsets.add(values_offsets))
++                        len(values_offsets), strings_offsets.add(values_offsets)))
+                 else:
+-                    print '\t{%s, %s(~0u)},' % (strings.add(field.name), field.s_name)
++                    print('\t{%s, %s(~0u)},' % (strings.add(field.name), field.s_name))
+                 fields_idx += 1
+ 
+-    print '};'
+-    print
+-
+-    print 'static const struct si_reg sid_reg_table[] = {'
++    print('};')
++    print()
++
++    print('static const struct si_reg sid_reg_table[] = {')
+     for reg in regs:
+         if len(reg.fields):
+-            print '\t{%s, %s, %s, %s},' % (strings.add(reg.name), reg.r_name,
+-                len(reg.fields), reg.fields_idx if reg.own_fields else reg.fields_owner.fields_idx)
++            print('\t{%s, %s, %s, %s},' % (strings.add(reg.name), reg.r_name,
++                len(reg.fields), reg.fields_idx if reg.own_fields else reg.fields_owner.fields_idx))
+         else:
+-            print '\t{%s, %s},' % (strings.add(reg.name), reg.r_name)
+-    print '};'
+-    print
++            print('\t{%s, %s},' % (strings.add(reg.name), reg.r_name))
++    print('};')
++    print()
+ 
+     strings.emit(sys.stdout, "sid_strings")
+ 
+-    print
++    print()
+ 
+     strings_offsets.emit(sys.stdout, "sid_strings_offsets")
+ 
+-    print
+-    print '#endif'
++    print()
++    print('#endif')
+ 
+ 
+ def main():
+--- ./src/amd/vulkan/vk_format_table.py	(original)
++++ ./src/amd/vulkan/vk_format_table.py	(refactored)
+@@ -79,24 +79,24 @@
+     if format.nr_channels() <= 1:
+         func(format.le_channels, format.le_swizzles)
+     else:
+-        print '#ifdef PIPE_ARCH_BIG_ENDIAN'
++        print('#ifdef PIPE_ARCH_BIG_ENDIAN')
+         func(format.be_channels, format.be_swizzles)
+-        print '#else'
++        print('#else')
+         func(format.le_channels, format.le_swizzles)
+-        print '#endif'
++        print('#endif')
+ 
+ def write_format_table(formats):
+-    print '/* This file is autogenerated by u_format_table.py from u_format.csv. Do not edit directly. */'
+-    print
++    print('/* This file is autogenerated by u_format_table.py from u_format.csv. Do not edit directly. */')
++    print()
+     # This will print the copyright message on the top of this file
+-    print CopyRight.strip()
+-    print
+-    print '#include "stdbool.h"'
+-    print '#include "vk_format.h"'
+-    print
++    print(CopyRight.strip())
++    print()
++    print('#include "stdbool.h"')
++    print('#include "vk_format.h"')
++    print()
+     
+     def do_channel_array(channels, swizzles):
+-        print "   {"
++        print("   {")
+         for i in range(4):
+             channel = channels[i]
+             if i < 3:
+@@ -104,13 +104,13 @@
+             else:
+                 sep = ""
+             if channel.size:
+-                print "      {%s, %s, %s, %s, %u, %u}%s\t/* %s = %s */" % (type_map[channel.type], bool_map(channel.norm), bool_map(channel.pure), bool_map(channel.scaled), channel.size, channel.shift, sep, "xyzw"[i], channel.name)
++                print("      {%s, %s, %s, %s, %u, %u}%s\t/* %s = %s */" % (type_map[channel.type], bool_map(channel.norm), bool_map(channel.pure), bool_map(channel.scaled), channel.size, channel.shift, sep, "xyzw"[i], channel.name))
+             else:
+-                print "      {0, 0, 0, 0, 0}%s" % (sep,)
+-        print "   },"
++                print("      {0, 0, 0, 0, 0}%s" % (sep,))
++        print("   },")
+ 
+     def do_swizzle_array(channels, swizzles):
+-        print "   {"
++        print("   {")
+         for i in range(4):
+             swizzle = swizzles[i]
+             if i < 3:
+@@ -121,43 +121,43 @@
+                 comment = colorspace_channels_map[format.colorspace][i]
+             except (KeyError, IndexError):
+                 comment = 'ignored'
+-            print "      %s%s\t/* %s */" % (swizzle_map[swizzle], sep, comment)
+-        print "   },"
++            print("      %s%s\t/* %s */" % (swizzle_map[swizzle], sep, comment))
++        print("   },")
+ 
+     for format in formats:
+-        print 'const struct vk_format_description'
+-        print 'vk_format_%s_description = {' % (format.short_name(),)
+-        print "   %s," % (format.name,)
+-        print "   \"%s\"," % (format.name,)
+-        print "   \"%s\"," % (format.short_name(),)
+-        print "   {%u, %u, %u},\t/* block */" % (format.block_width, format.block_height, format.block_size())
+-        print "   %s," % (layout_map(format.layout),)
+-        print "   %u,\t/* nr_channels */" % (format.nr_channels(),)
+-        print "   %s,\t/* is_array */" % (bool_map(format.is_array()),)
+-        print "   %s,\t/* is_bitmask */" % (bool_map(format.is_bitmask()),)
+-        print "   %s,\t/* is_mixed */" % (bool_map(format.is_mixed()),)
++        print('const struct vk_format_description')
++        print('vk_format_%s_description = {' % (format.short_name(),))
++        print("   %s," % (format.name,))
++        print("   \"%s\"," % (format.name,))
++        print("   \"%s\"," % (format.short_name(),))
++        print("   {%u, %u, %u},\t/* block */" % (format.block_width, format.block_height, format.block_size()))
++        print("   %s," % (layout_map(format.layout),))
++        print("   %u,\t/* nr_channels */" % (format.nr_channels(),))
++        print("   %s,\t/* is_array */" % (bool_map(format.is_array()),))
++        print("   %s,\t/* is_bitmask */" % (bool_map(format.is_bitmask()),))
++        print("   %s,\t/* is_mixed */" % (bool_map(format.is_mixed()),))
+         print_channels(format, do_channel_array)
+         print_channels(format, do_swizzle_array)
+-        print "   %s," % (colorspace_map(format.colorspace),)
+-        print "};"
+-        print
++        print("   %s," % (colorspace_map(format.colorspace),))
++        print("};")
++        print()
+         
+-    print "const struct vk_format_description *"
+-    print "vk_format_description(VkFormat format)"
+-    print "{"
+-    print "   if (format > VK_FORMAT_END_RANGE) {"
+-    print "      return NULL;"
+-    print "   }"
+-    print
+-    print "   switch (format) {"
++    print("const struct vk_format_description *")
++    print("vk_format_description(VkFormat format)")
++    print("{")
++    print("   if (format > VK_FORMAT_END_RANGE) {")
++    print("      return NULL;")
++    print("   }")
++    print()
++    print("   switch (format) {")
+     for format in formats:
+-        print "   case %s:" % format.name
+-        print "      return &vk_format_%s_description;" % (format.short_name(),)
+-    print "   default:"
+-    print "      return NULL;"
+-    print "   }"
+-    print "}"
+-    print
++        print("   case %s:" % format.name)
++        print("      return &vk_format_%s_description;" % (format.short_name(),))
++    print("   default:")
++    print("      return NULL;")
++    print("   }")
++    print("}")
++    print()
+ 
+ 
+ def main():
+--- ./src/compiler/glsl/ir_expression_operation.py	(original)
++++ ./src/compiler/glsl/ir_expression_operation.py	(refactored)
+@@ -62,7 +62,7 @@
+    def __iter__(self):
+       return self
+ 
+-   def next(self):
++   def __next__(self):
+       if self.i < len(self.source_types):
+          i = self.i
+          self.i += 1
+@@ -685,7 +685,7 @@
+    #
+    # See also lower_instructions_visitor::ldexp_to_arith
+    operation("csel", 3,
+-             all_signatures=zip(all_types, zip(len(all_types) * (bool_type,), all_types, all_types)),
++             all_signatures=list(zip(all_types, list(zip(len(all_types) * (bool_type,), all_types, all_types)))),
+              c_expression="{src0} ? {src1} : {src2}"),
+ 
+    operation("bitfield_extract", 3,
+@@ -781,9 +781,9 @@
+          if lasts[i] is None:
+             lasts[i] = item
+ 
+-      print(enum_template.render(values=ir_expression_operation,
+-                                 lasts=lasts))
++      print((enum_template.render(values=ir_expression_operation,
++                                 lasts=lasts)))
+    elif sys.argv[1] == "strings":
+-      print(strings_template.render(values=ir_expression_operation))
++      print((strings_template.render(values=ir_expression_operation)))
+    elif sys.argv[1] == "constant":
+-      print(constant_template.render(values=ir_expression_operation))
++      print((constant_template.render(values=ir_expression_operation)))
+--- ./src/compiler/glsl/tests/compare_ir.py	(original)
++++ ./src/compiler/glsl/tests/compare_ir.py	(refactored)
+@@ -33,7 +33,7 @@
+ from sexps import *
+ 
+ if len(sys.argv) != 3:
+-    print 'Usage: python2 ./compare_ir.py <file1> <file2>'
++    print('Usage: python2 ./compare_ir.py <file1> <file2>')
+     exit(1)
+ 
+ with open(sys.argv[1]) as f:
+--- ./src/compiler/glsl/tests/sexps.py	(original)
++++ ./src/compiler/glsl/tests/sexps.py	(refactored)
+@@ -39,7 +39,7 @@
+     if isinstance(sexp, list):
+         for s in sexp:
+             check_sexp(s)
+-    elif not isinstance(sexp, basestring):
++    elif not isinstance(sexp, str):
+         raise Exception('Not a sexp: {0!r}'.format(sexp))
+ 
+ def parse_sexp(sexp):
+@@ -70,7 +70,7 @@
+     """Convert a sexp, represented as nested lists containing strings,
+     into a single string of the form parseable by mesa.
+     """
+-    if isinstance(sexp, basestring):
++    if isinstance(sexp, str):
+         return sexp
+     assert isinstance(sexp, list)
+     result = ''
+--- ./src/compiler/glsl/tests/lower_jumps/create_test_cases.py	(original)
++++ ./src/compiler/glsl/tests/lower_jumps/create_test_cases.py	(refactored)
+@@ -64,7 +64,7 @@
+                     else:
+                         make_declarations(s, already_declared)
+     make_declarations(body)
+-    return declarations.values() + \
++    return list(declarations.values()) + \
+         [['function', f_name, ['signature', ret_type, ['parameters'], body]]]
+ 
+ 
+@@ -305,7 +305,7 @@
+         f.write(doc_string)
+         f.write('{0} <<EOF\n'.format(bash_quote(*args)))
+         f.write('{0}\nEOF\n'.format(input_str))
+-    os.chmod(test_file, 0774)
++    os.chmod(test_file, 0o774)
+     expected_file = os.path.join(outdir, '{0}.opt_test.expected'.format(test_name))
+     with open(expected_file, 'w') as f:
+         f.write('{0}\n'.format(expected_output))
+
+--- ./src/compiler/nir/nir_builder_opcodes_h.py	(original)
++++ ./src/compiler/nir/nir_builder_opcodes_h.py	(refactored)
+@@ -46,4 +46,4 @@
+ from nir_opcodes import opcodes
+ from mako.template import Template
+ 
+-print Template(template).render(opcodes=opcodes)
++print(Template(template).render(opcodes=opcodes))
+--- ./src/compiler/nir/nir_constant_expressions.py	(original)
++++ ./src/compiler/nir/nir_constant_expressions.py	(refactored)
+@@ -431,8 +431,8 @@
+ from nir_opcodes import opcodes
+ from mako.template import Template
+ 
+-print Template(template).render(opcodes=opcodes, type_sizes=type_sizes,
++print(Template(template).render(opcodes=opcodes, type_sizes=type_sizes,
+                                 type_has_size=type_has_size,
+                                 type_add_size=type_add_size,
+                                 op_bit_sizes=op_bit_sizes,
+-                                get_const_field=get_const_field)
++                                get_const_field=get_const_field))
+--- ./src/compiler/nir/nir_opcodes.py	(original)
++++ ./src/compiler/nir/nir_opcodes.py	(refactored)
+@@ -341,8 +341,8 @@
+ """)
+ 
+ 
+-for i in xrange(1, 5):
+-   for j in xrange(1, 5):
++for i in range(1, 5):
++   for j in range(1, 5):
+       unop_horiz("fnoise{0}_{1}".format(i, j), i, tfloat, j, tfloat, "0.0f")
+ 
+ def binop_convert(name, out_type, in_type, alg_props, const_expr):
+--- ./src/compiler/nir/nir_opcodes_c.py	(original)
++++ ./src/compiler/nir/nir_opcodes_c.py	(refactored)
+@@ -117,4 +117,4 @@
+ };
+ """)
+ 
+-print template.render(opcodes=opcodes)
++print(template.render(opcodes=opcodes))
+--- ./src/compiler/nir/nir_opcodes_h.py	(original)
++++ ./src/compiler/nir/nir_opcodes_h.py	(refactored)
+@@ -43,4 +43,4 @@
+ from nir_opcodes import opcodes
+ from mako.template import Template
+ 
+-print Template(template).render(opcodes=opcodes)
++print(Template(template).render(opcodes=opcodes))
+--- ./src/compiler/nir/nir_opt_algebraic.py	(original)
++++ ./src/compiler/nir/nir_opt_algebraic.py	(refactored)
+@@ -545,6 +545,6 @@
+    (('fmax', ('fadd(is_used_once)', '#c', a), ('fadd(is_used_once)', '#c', b)), ('fadd', c, ('fmax', a, b))),
+ ]
+ 
+-print nir_algebraic.AlgebraicPass("nir_opt_algebraic", optimizations).render()
+-print nir_algebraic.AlgebraicPass("nir_opt_algebraic_late",
+-                                  late_optimizations).render()
++print(nir_algebraic.AlgebraicPass("nir_opt_algebraic", optimizations).render())
++print(nir_algebraic.AlgebraicPass("nir_opt_algebraic_late",
++                                  late_optimizations).render())
+--- ./src/egl/generate/genCommon.py	(original)
++++ ./src/egl/generate/genCommon.py	(refactored)
+@@ -63,7 +63,7 @@
+     for root in roots:
+         for func in _getFunctionList(root):
+             functions[func.name] = func
+-    functions = functions.values()
++    functions = list(functions.values())
+ 
+     # Sort the function list by name.
+     functions = sorted(functions, key=lambda f: f.name)
+--- ./src/gallium/auxiliary/indices/u_indices_gen.py	(original)
++++ ./src/gallium/auxiliary/indices/u_indices_gen.py	(refactored)
+@@ -62,16 +62,16 @@
+            'PIPE_PRIM_TRIANGLES_ADJACENCY',
+            'PIPE_PRIM_TRIANGLE_STRIP_ADJACENCY')
+ 
+-longprim = dict(zip(PRIMS, LONGPRIMS))
++longprim = dict(list(zip(PRIMS, LONGPRIMS)))
+ intype_idx = dict(ubyte='IN_UBYTE', ushort='IN_USHORT', uint='IN_UINT')
+ outtype_idx = dict(ushort='OUT_USHORT', uint='OUT_UINT')
+ pv_idx = dict(first='PV_FIRST', last='PV_LAST')
+ pr_idx = dict(prdisable='PR_DISABLE', prenable='PR_ENABLE')
+ 
+ def prolog():
+-    print '''/* File automatically generated by u_indices_gen.py */'''
+-    print copyright
+-    print r'''
++    print('''/* File automatically generated by u_indices_gen.py */''')
++    print(copyright)
++    print(r'''
+ 
+ /**
+  * @file
+@@ -107,7 +107,7 @@
+ static u_generate_func  generate[OUT_COUNT][PV_COUNT][PV_COUNT][PRIM_COUNT];
+ 
+ 
+-'''
++''')
+ 
+ def vert( intype, outtype, v0 ):
+     if intype == GENERATE:
+@@ -116,30 +116,30 @@
+         return '(' + outtype + ')in[' + v0 + ']'
+ 
+ def point( intype, outtype, ptr, v0 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
+ 
+ def line( intype, outtype, ptr, v0, v1 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
+-    print '      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
++    print('      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';')
+ 
+ def tri( intype, outtype, ptr, v0, v1, v2 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
+-    print '      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';'
+-    print '      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
++    print('      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';')
++    print('      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';')
+ 
+ def lineadj( intype, outtype, ptr, v0, v1, v2, v3 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
+-    print '      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';'
+-    print '      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';'
+-    print '      (' + ptr + ')[3] = ' + vert( intype, outtype, v3 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
++    print('      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';')
++    print('      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';')
++    print('      (' + ptr + ')[3] = ' + vert( intype, outtype, v3 ) + ';')
+ 
+ def triadj( intype, outtype, ptr, v0, v1, v2, v3, v4, v5 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
+-    print '      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';'
+-    print '      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';'
+-    print '      (' + ptr + ')[3] = ' + vert( intype, outtype, v3 ) + ';'
+-    print '      (' + ptr + ')[4] = ' + vert( intype, outtype, v4 ) + ';'
+-    print '      (' + ptr + ')[5] = ' + vert( intype, outtype, v5 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
++    print('      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';')
++    print('      (' + ptr + ')[2] = ' + vert( intype, outtype, v2 ) + ';')
++    print('      (' + ptr + ')[3] = ' + vert( intype, outtype, v3 ) + ';')
++    print('      (' + ptr + ')[4] = ' + vert( intype, outtype, v4 ) + ';')
++    print('      (' + ptr + ')[5] = ' + vert( intype, outtype, v5 ) + ';')
+ 
+ def do_point( intype, outtype, ptr, v0 ):
+     point( intype, outtype, ptr, v0 )
+@@ -186,231 +186,231 @@
+         return 'translate_' + prim + '_' + intype + '2' + outtype + '_' + inpv + '2' + outpv + '_' + pr
+ 
+ def preamble(intype, outtype, inpv, outpv, pr, prim):
+-    print 'static void ' + name( intype, outtype, inpv, outpv, pr, prim ) + '('
++    print('static void ' + name( intype, outtype, inpv, outpv, pr, prim ) + '(')
+     if intype != GENERATE:
+-        print '    const void * _in,'
+-    print '    unsigned start,'
++        print('    const void * _in,')
++    print('    unsigned start,')
+     if intype != GENERATE:
+-        print '    unsigned in_nr,'
+-    print '    unsigned out_nr,'
++        print('    unsigned in_nr,')
++    print('    unsigned out_nr,')
+     if intype != GENERATE:
+-        print '    unsigned restart_index,'
+-    print '    void *_out )'
+-    print '{'
++        print('    unsigned restart_index,')
++    print('    void *_out )')
++    print('{')
+     if intype != GENERATE:
+-        print '  const ' + intype + '*in = (const ' + intype + '*)_in;'
+-    print '  ' + outtype + ' *out = (' + outtype + '*)_out;'
+-    print '  unsigned i, j;'
+-    print '  (void)j;'
++        print('  const ' + intype + '*in = (const ' + intype + '*)_in;')
++    print('  ' + outtype + ' *out = (' + outtype + '*)_out;')
++    print('  unsigned i, j;')
++    print('  (void)j;')
+ 
+ def postamble():
+-    print '}'
++    print('}')
+ 
+ 
+ def points(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='points')
+-    print '  for (i = start; i < (out_nr+start); i++) { '
++    print('  for (i = start; i < (out_nr+start); i++) { ')
+     do_point( intype, outtype, 'out+i',  'i' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ def lines(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='lines')
+-    print '  for (i = start; i < (out_nr+start); i+=2) { '
++    print('  for (i = start; i < (out_nr+start); i+=2) { ')
+     do_line( intype, outtype, 'out+i',  'i', 'i+1', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ def linestrip(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='linestrip')
+-    print '  for (i = start, j = 0; j < out_nr; j+=2, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=2, i++) { ')
+     do_line( intype, outtype, 'out+j',  'i', 'i+1', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ def lineloop(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='lineloop')
+-    print '  for (i = start, j = 0; j < out_nr - 2; j+=2, i++) { '
++    print('  for (i = start, j = 0; j < out_nr - 2; j+=2, i++) { ')
+     do_line( intype, outtype, 'out+j',  'i', 'i+1', inpv, outpv );
+-    print '   }'
++    print('   }')
+     do_line( intype, outtype, 'out+j',  'i', 'start', inpv, outpv );
+     postamble()
+ 
+ def tris(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='tris')
+-    print '  for (i = start; i < (out_nr+start); i+=3) { '
++    print('  for (i = start; i < (out_nr+start); i+=3) { ')
+     do_tri( intype, outtype, 'out+i',  'i', 'i+1', 'i+2', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def tristrip(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='tristrip')
+-    print '  for (i = start, j = 0; j < out_nr; j+=3, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=3, i++) { ')
+     if inpv == FIRST:
+         do_tri( intype, outtype, 'out+j',  'i', 'i+1+(i&1)', 'i+2-(i&1)', inpv, outpv );
+     else:
+         do_tri( intype, outtype, 'out+j',  'i+(i&1)', 'i+1-(i&1)', 'i+2', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def trifan(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='trifan')
+-    print '  for (i = start, j = 0; j < out_nr; j+=3, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=3, i++) { ')
+     do_tri( intype, outtype, 'out+j',  'start', 'i+1', 'i+2', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ 
+ def polygon(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='polygon')
+-    print '  for (i = start, j = 0; j < out_nr; j+=3, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=3, i++) { ')
+     if pr == PRENABLE:
+-        print 'restart:'
+-        print '      if (i + 3 > in_nr) {'
+-        print '         (out+j+0)[0] = restart_index;'
+-        print '         (out+j+0)[1] = restart_index;'
+-        print '         (out+j+0)[2] = restart_index;'
+-        print '         continue;'
+-        print '      }'
+-        print '      if (in[i + 0] == restart_index) {'
+-        print '         i += 1;'
+-        print '         start = i;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 1] == restart_index) {'
+-        print '         i += 2;'
+-        print '         start = i;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 2] == restart_index) {'
+-        print '         i += 3;'
+-        print '         start = i;'
+-        print '         goto restart;'
+-        print '      }'
++        print('restart:')
++        print('      if (i + 3 > in_nr) {')
++        print('         (out+j+0)[0] = restart_index;')
++        print('         (out+j+0)[1] = restart_index;')
++        print('         (out+j+0)[2] = restart_index;')
++        print('         continue;')
++        print('      }')
++        print('      if (in[i + 0] == restart_index) {')
++        print('         i += 1;')
++        print('         start = i;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 1] == restart_index) {')
++        print('         i += 2;')
++        print('         start = i;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 2] == restart_index) {')
++        print('         i += 3;')
++        print('         start = i;')
++        print('         goto restart;')
++        print('      }')
+ 
+     if inpv == FIRST:
+         do_tri( intype, outtype, 'out+j',  'start', 'i+1', 'i+2', inpv, outpv );
+     else:
+         do_tri( intype, outtype, 'out+j',  'i+1', 'i+2', 'start', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def quads(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='quads')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i+=4) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i+=4) { ')
+     if pr == PRENABLE:
+-        print 'restart:'
+-        print '      if (i + 4 > in_nr) {'
+-        print '         (out+j+0)[0] = restart_index;'
+-        print '         (out+j+0)[1] = restart_index;'
+-        print '         (out+j+0)[2] = restart_index;'
+-        print '         (out+j+3)[0] = restart_index;'
+-        print '         (out+j+3)[1] = restart_index;'
+-        print '         (out+j+3)[2] = restart_index;'
+-        print '         continue;'
+-        print '      }'
+-        print '      if (in[i + 0] == restart_index) {'
+-        print '         i += 1;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 1] == restart_index) {'
+-        print '         i += 2;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 2] == restart_index) {'
+-        print '         i += 3;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 3] == restart_index) {'
+-        print '         i += 4;'
+-        print '         goto restart;'
+-        print '      }'
++        print('restart:')
++        print('      if (i + 4 > in_nr) {')
++        print('         (out+j+0)[0] = restart_index;')
++        print('         (out+j+0)[1] = restart_index;')
++        print('         (out+j+0)[2] = restart_index;')
++        print('         (out+j+3)[0] = restart_index;')
++        print('         (out+j+3)[1] = restart_index;')
++        print('         (out+j+3)[2] = restart_index;')
++        print('         continue;')
++        print('      }')
++        print('      if (in[i + 0] == restart_index) {')
++        print('         i += 1;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 1] == restart_index) {')
++        print('         i += 2;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 2] == restart_index) {')
++        print('         i += 3;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 3] == restart_index) {')
++        print('         i += 4;')
++        print('         goto restart;')
++        print('      }')
+ 
+     do_quad( intype, outtype, 'out+j', 'i+0', 'i+1', 'i+2', 'i+3', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def quadstrip(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='quadstrip')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i+=2) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i+=2) { ')
+     if pr == PRENABLE:
+-        print 'restart:'
+-        print '      if (i + 4 > in_nr) {'
+-        print '         (out+j+0)[0] = restart_index;'
+-        print '         (out+j+0)[1] = restart_index;'
+-        print '         (out+j+0)[2] = restart_index;'
+-        print '         (out+j+3)[0] = restart_index;'
+-        print '         (out+j+3)[1] = restart_index;'
+-        print '         (out+j+3)[2] = restart_index;'
+-        print '         continue;'
+-        print '      }'
+-        print '      if (in[i + 0] == restart_index) {'
+-        print '         i += 1;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 1] == restart_index) {'
+-        print '         i += 2;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 2] == restart_index) {'
+-        print '         i += 3;'
+-        print '         goto restart;'
+-        print '      }'
+-        print '      if (in[i + 3] == restart_index) {'
+-        print '         i += 4;'
+-        print '         goto restart;'
+-        print '      }'
++        print('restart:')
++        print('      if (i + 4 > in_nr) {')
++        print('         (out+j+0)[0] = restart_index;')
++        print('         (out+j+0)[1] = restart_index;')
++        print('         (out+j+0)[2] = restart_index;')
++        print('         (out+j+3)[0] = restart_index;')
++        print('         (out+j+3)[1] = restart_index;')
++        print('         (out+j+3)[2] = restart_index;')
++        print('         continue;')
++        print('      }')
++        print('      if (in[i + 0] == restart_index) {')
++        print('         i += 1;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 1] == restart_index) {')
++        print('         i += 2;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 2] == restart_index) {')
++        print('         i += 3;')
++        print('         goto restart;')
++        print('      }')
++        print('      if (in[i + 3] == restart_index) {')
++        print('         i += 4;')
++        print('         goto restart;')
++        print('      }')
+     if inpv == LAST:
+         do_quad( intype, outtype, 'out+j', 'i+2', 'i+0', 'i+1', 'i+3', inpv, outpv );
+     else:
+         do_quad( intype, outtype, 'out+j', 'i+0', 'i+1', 'i+3', 'i+2', inpv, outpv );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def linesadj(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='linesadj')
+-    print '  for (i = start; i < (out_nr+start); i+=4) { '
++    print('  for (i = start; i < (out_nr+start); i+=4) { ')
+     do_lineadj( intype, outtype, 'out+i',  'i+0', 'i+1', 'i+2', 'i+3', inpv, outpv )
+-    print '  }'
++    print('  }')
+     postamble()
+ 
+ 
+ def linestripadj(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='linestripadj')
+-    print '  for (i = start, j = 0; j < out_nr; j+=4, i++) {'
++    print('  for (i = start, j = 0; j < out_nr; j+=4, i++) {')
+     do_lineadj( intype, outtype, 'out+j',  'i+0', 'i+1', 'i+2', 'i+3', inpv, outpv )
+-    print '  }'
++    print('  }')
+     postamble()
+ 
+ 
+ def trisadj(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='trisadj')
+-    print '  for (i = start; i < (out_nr+start); i+=6) { '
++    print('  for (i = start; i < (out_nr+start); i+=6) { ')
+     do_triadj( intype, outtype, 'out+i',  'i+0', 'i+1', 'i+2', 'i+3',
+                'i+4', 'i+5', inpv, outpv )
+-    print '  }'
++    print('  }')
+     postamble()
+ 
+ 
+ def tristripadj(intype, outtype, inpv, outpv, pr):
+     preamble(intype, outtype, inpv, outpv, pr, prim='tristripadj')
+-    print '  for (i = start, j = 0; j < out_nr; i+=2, j+=6) { '
+-    print '    if (i % 4 == 0) {'
+-    print '      /* even triangle */'
++    print('  for (i = start, j = 0; j < out_nr; i+=2, j+=6) { ')
++    print('    if (i % 4 == 0) {')
++    print('      /* even triangle */')
+     do_triadj( intype, outtype, 'out+j',
+                'i+0', 'i+1', 'i+2', 'i+3', 'i+4', 'i+5', inpv, outpv )
+-    print '    } else {'
+-    print '      /* odd triangle */'
++    print('    } else {')
++    print('      /* odd triangle */')
+     do_triadj( intype, outtype, 'out+j',
+                'i+2', 'i-2', 'i+0', 'i+3', 'i+4', 'i+6', inpv, outpv )
+-    print '    }'
+-    print '  }'
++    print('    }')
++    print('  }')
+     postamble()
+ 
+ 
+@@ -439,21 +439,21 @@
+ 
+ def init(intype, outtype, inpv, outpv, pr, prim):
+     if intype == GENERATE:
+-        print ('generate[' + 
++        print(('generate[' + 
+                outtype_idx[outtype] + 
+                '][' + pv_idx[inpv] + 
+                '][' + pv_idx[outpv] + 
+                '][' + longprim[prim] + 
+-               '] = ' + name( intype, outtype, inpv, outpv, pr, prim ) + ';')
+-    else:
+-        print ('translate[' + 
++               '] = ' + name( intype, outtype, inpv, outpv, pr, prim ) + ';'))
++    else:
++        print(('translate[' + 
+                intype_idx[intype] + 
+                '][' + outtype_idx[outtype] + 
+                '][' + pv_idx[inpv] + 
+                '][' + pv_idx[outpv] +
+                '][' + pr_idx[pr] + 
+                '][' + longprim[prim] + 
+-               '] = ' + name( intype, outtype, inpv, outpv, pr, prim ) + ';')
++               '] = ' + name( intype, outtype, inpv, outpv, pr, prim ) + ';'))
+ 
+ 
+ def emit_all_inits():
+@@ -466,19 +466,19 @@
+                             init(intype, outtype, inpv, outpv, pr, prim)
+ 
+ def emit_init():
+-    print 'void u_index_init( void )'
+-    print '{'
+-    print '  static int firsttime = 1;'
+-    print '  if (!firsttime) return;'
+-    print '  firsttime = 0;'
++    print('void u_index_init( void )')
++    print('{')
++    print('  static int firsttime = 1;')
++    print('  if (!firsttime) return;')
++    print('  firsttime = 0;')
+     emit_all_inits()
+-    print '}'
++    print('}')
+ 
+ 
+     
+ 
+ def epilog():
+-    print '#include "indices/u_indices.c"'
++    print('#include "indices/u_indices.c"')
+ 
+ 
+ def main():
+--- ./src/gallium/auxiliary/indices/u_unfilled_gen.py	(original)
++++ ./src/gallium/auxiliary/indices/u_unfilled_gen.py	(refactored)
+@@ -47,15 +47,15 @@
+            'PIPE_PRIM_TRIANGLES_ADJACENCY',
+            'PIPE_PRIM_TRIANGLE_STRIP_ADJACENCY')
+ 
+-longprim = dict(zip(PRIMS, LONGPRIMS))
++longprim = dict(list(zip(PRIMS, LONGPRIMS)))
+ intype_idx = dict(ubyte='IN_UBYTE', ushort='IN_USHORT', uint='IN_UINT')
+ outtype_idx = dict(ushort='OUT_USHORT', uint='OUT_UINT')
+ 
+ 
+ def prolog():
+-    print '''/* File automatically generated by u_unfilled_gen.py */'''
+-    print copyright
+-    print r'''
++    print('''/* File automatically generated by u_unfilled_gen.py */''')
++    print(copyright)
++    print(r'''
+ 
+ /**
+  * @file
+@@ -93,7 +93,7 @@
+ static u_generate_func generate_line[OUT_COUNT][PRIM_COUNT];
+ static u_translate_func translate_line[IN_COUNT][OUT_COUNT][PRIM_COUNT];
+ 
+-'''
++''')
+ 
+ def vert( intype, outtype, v0 ):
+     if intype == GENERATE:
+@@ -102,8 +102,8 @@
+         return '(' + outtype + ')in[' + v0 + ']'
+ 
+ def line( intype, outtype, ptr, v0, v1 ):
+-    print '      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';'
+-    print '      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';'
++    print('      (' + ptr + ')[0] = ' + vert( intype, outtype, v0 ) + ';')
++    print('      (' + ptr + ')[1] = ' + vert( intype, outtype, v1 ) + ';')
+ 
+ # XXX: have the opportunity here to avoid over-drawing shared lines in
+ # tristrips, fans, etc, by integrating this into the calling functions
+@@ -127,89 +127,89 @@
+         return 'translate_' + prim + '_' + intype + '2' + outtype
+ 
+ def preamble(intype, outtype, prim):
+-    print 'static void ' + name( intype, outtype, prim ) + '('
+-    if intype != GENERATE:
+-        print '    const void * _in,'
+-    print '    unsigned start,'
+-    if intype != GENERATE:
+-        print '    unsigned in_nr,'
+-    print '    unsigned out_nr,'
+-    if intype != GENERATE:
+-        print '    unsigned restart_index,'
+-    print '    void *_out )'
+-    print '{'
+-    if intype != GENERATE:
+-        print '  const ' + intype + '*in = (const ' + intype + '*)_in;'
+-    print '  ' + outtype + ' *out = (' + outtype + '*)_out;'
+-    print '  unsigned i, j;'
+-    print '  (void)j;'
++    print('static void ' + name( intype, outtype, prim ) + '(')
++    if intype != GENERATE:
++        print('    const void * _in,')
++    print('    unsigned start,')
++    if intype != GENERATE:
++        print('    unsigned in_nr,')
++    print('    unsigned out_nr,')
++    if intype != GENERATE:
++        print('    unsigned restart_index,')
++    print('    void *_out )')
++    print('{')
++    if intype != GENERATE:
++        print('  const ' + intype + '*in = (const ' + intype + '*)_in;')
++    print('  ' + outtype + ' *out = (' + outtype + '*)_out;')
++    print('  unsigned i, j;')
++    print('  (void)j;')
+ 
+ def postamble():
+-    print '}'
++    print('}')
+ 
+ 
+ def tris(intype, outtype):
+     preamble(intype, outtype, prim='tris')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i+=3) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i+=3) { ')
+     do_tri( intype, outtype, 'out+j',  'i', 'i+1', 'i+2' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def tristrip(intype, outtype):
+     preamble(intype, outtype, prim='tristrip')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i++) { ')
+     do_tri( intype, outtype, 'out+j',  'i', 'i+1/*+(i&1)*/', 'i+2/*-(i&1)*/' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def trifan(intype, outtype):
+     preamble(intype, outtype, prim='trifan')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i++) { ')
+     do_tri( intype, outtype, 'out+j',  '0', 'i+1', 'i+2' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ 
+ def polygon(intype, outtype):
+     preamble(intype, outtype, prim='polygon')
+-    print '  for (i = start, j = 0; j < out_nr; j+=2, i++) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=2, i++) { ')
+     line( intype, outtype, 'out+j', 'i', '(i+1)%(out_nr/2)' )
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def quads(intype, outtype):
+     preamble(intype, outtype, prim='quads')
+-    print '  for (i = start, j = 0; j < out_nr; j+=8, i+=4) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=8, i+=4) { ')
+     do_quad( intype, outtype, 'out+j', 'i+0', 'i+1', 'i+2', 'i+3' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def quadstrip(intype, outtype):
+     preamble(intype, outtype, prim='quadstrip')
+-    print '  for (i = start, j = 0; j < out_nr; j+=8, i+=2) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=8, i+=2) { ')
+     do_quad( intype, outtype, 'out+j', 'i+2', 'i+0', 'i+1', 'i+3' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def trisadj(intype, outtype):
+     preamble(intype, outtype, prim='trisadj')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i+=6) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i+=6) { ')
+     do_tri( intype, outtype, 'out+j',  'i', 'i+2', 'i+4' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+ def tristripadj(intype, outtype):
+     preamble(intype, outtype, prim='tristripadj')
+-    print '  for (i = start, j = 0; j < out_nr; j+=6, i+=2) { '
++    print('  for (i = start, j = 0; j < out_nr; j+=6, i+=2) { ')
+     do_tri( intype, outtype, 'out+j',  'i', 'i+2', 'i+4' );
+-    print '   }'
++    print('   }')
+     postamble()
+ 
+ 
+@@ -227,16 +227,16 @@
+ 
+ def init(intype, outtype, prim):
+     if intype == GENERATE:
+-        print ('generate_line[' + 
++        print(('generate_line[' + 
+                outtype_idx[outtype] + 
+                '][' + longprim[prim] + 
+-               '] = ' + name( intype, outtype, prim ) + ';')
++               '] = ' + name( intype, outtype, prim ) + ';'))
+     else:
+-        print ('translate_line[' + 
++        print(('translate_line[' + 
+                intype_idx[intype] + 
+                '][' + outtype_idx[outtype] + 
+                '][' + longprim[prim] + 
+-               '] = ' + name( intype, outtype, prim ) + ';')
++               '] = ' + name( intype, outtype, prim ) + ';'))
+ 
+ 
+ def emit_all_inits():
+@@ -246,19 +246,19 @@
+                 init(intype, outtype, prim)
+ 
+ def emit_init():
+-    print 'void u_unfilled_init( void )'
+-    print '{'
+-    print '  static int firsttime = 1;'
+-    print '  if (!firsttime) return;'
+-    print '  firsttime = 0;'
++    print('void u_unfilled_init( void )')
++    print('{')
++    print('  static int firsttime = 1;')
++    print('  if (!firsttime) return;')
++    print('  firsttime = 0;')
+     emit_all_inits()
+-    print '}'
++    print('}')
+ 
+ 
+     
+ 
+ def epilog():
+-    print '#include "indices/u_unfilled_indices.c"'
++    print('#include "indices/u_unfilled_indices.c"')
+ 
+ 
+ def main():
+--- ./src/gallium/auxiliary/util/u_format_pack.py	(original)
++++ ./src/gallium/auxiliary/util/u_format_pack.py	(refactored)
+@@ -53,11 +53,11 @@
+     if format.nr_channels() <= 1:
+         func(format.le_channels, format.le_swizzles)
+     else:
+-        print '#ifdef PIPE_ARCH_BIG_ENDIAN'
++        print('#ifdef PIPE_ARCH_BIG_ENDIAN')
+         func(format.be_channels, format.be_swizzles)
+-        print '#else'
++        print('#else')
+         func(format.le_channels, format.le_swizzles)
+-        print '#endif'
++        print('#endif')
+ 
+ def generate_format_type(format):
+     '''Generate a structure that describes the format.'''
+@@ -68,18 +68,18 @@
+         for channel in channels:
+             if channel.type == VOID:
+                 if channel.size:
+-                    print '      unsigned %s:%u;' % (channel.name, channel.size)
++                    print('      unsigned %s:%u;' % (channel.name, channel.size))
+             elif channel.type == UNSIGNED:
+-                print '      unsigned %s:%u;' % (channel.name, channel.size)
++                print('      unsigned %s:%u;' % (channel.name, channel.size))
+             elif channel.type in (SIGNED, FIXED):
+-                print '      int %s:%u;' % (channel.name, channel.size)
++                print('      int %s:%u;' % (channel.name, channel.size))
+             elif channel.type == FLOAT:
+                 if channel.size == 64:
+-                    print '      double %s;' % (channel.name)
++                    print('      double %s;' % (channel.name))
+                 elif channel.size == 32:
+-                    print '      float %s;' % (channel.name)
++                    print('      float %s;' % (channel.name))
+                 else:
+-                    print '      unsigned %s:%u;' % (channel.name, channel.size)
++                    print('      unsigned %s:%u;' % (channel.name, channel.size))
+             else:
+                 assert 0
+ 
+@@ -88,41 +88,41 @@
+             assert channel.size % 8 == 0 and is_pot(channel.size)
+             if channel.type == VOID:
+                 if channel.size:
+-                    print '      uint%u_t %s;' % (channel.size, channel.name)
++                    print('      uint%u_t %s;' % (channel.size, channel.name))
+             elif channel.type == UNSIGNED:
+-                print '      uint%u_t %s;' % (channel.size, channel.name)
++                print('      uint%u_t %s;' % (channel.size, channel.name))
+             elif channel.type in (SIGNED, FIXED):
+-                print '      int%u_t %s;' % (channel.size, channel.name)
++                print('      int%u_t %s;' % (channel.size, channel.name))
+             elif channel.type == FLOAT:
+                 if channel.size == 64:
+-                    print '      double %s;' % (channel.name)
++                    print('      double %s;' % (channel.name))
+                 elif channel.size == 32:
+-                    print '      float %s;' % (channel.name)
++                    print('      float %s;' % (channel.name))
+                 elif channel.size == 16:
+-                    print '      uint16_t %s;' % (channel.name)
++                    print('      uint16_t %s;' % (channel.name))
+                 else:
+                     assert 0
+             else:
+                 assert 0
+ 
+-    print 'union util_format_%s {' % format.short_name()
++    print('union util_format_%s {' % format.short_name())
+     
+     if format.block_size() in (8, 16, 32, 64):
+-        print '   uint%u_t value;' % (format.block_size(),)
++        print('   uint%u_t value;' % (format.block_size(),))
+ 
+     use_bitfields = False
+     for channel in format.le_channels:
+         if channel.size % 8 or not is_pot(channel.size):
+             use_bitfields = True
+ 
+-    print '   struct {'
++    print('   struct {')
+     if use_bitfields:
+         print_channels(format, generate_bitfields)
+     else:
+         print_channels(format, generate_full_fields)
+-    print '   } chan;'
+-    print '};'
+-    print
++    print('   } chan;')
++    print('};')
++    print()
+ 
+ 
+ def is_format_supported(format):
+@@ -210,7 +210,7 @@
+     '''Truncate an integer so it can be represented exactly with a floating
+     point mantissa'''
+ 
+-    assert isinstance(x, (int, long))
++    assert isinstance(x, int)
+ 
+     s = 1
+     if x < 0:
+@@ -234,7 +234,7 @@
+     '''Get the value of unity for this type.'''
+     if type.type == FLOAT:
+         if type.size <= 32 \
+-            and isinstance(value, (int, long)):
++            and isinstance(value, int):
+             return truncate_mantissa(value, 23)
+         return value
+     if type.type == FIXED:
+@@ -444,15 +444,15 @@
+ 
+     def unpack_from_bitmask(channels, swizzles):
+         depth = format.block_size()
+-        print '         uint%u_t value = *(const uint%u_t *)src;' % (depth, depth) 
++        print('         uint%u_t value = *(const uint%u_t *)src;' % (depth, depth)) 
+ 
+         # Declare the intermediate variables
+         for i in range(format.nr_channels()):
+             src_channel = channels[i]
+             if src_channel.type == UNSIGNED:
+-                print '         uint%u_t %s;' % (depth, src_channel.name)
++                print('         uint%u_t %s;' % (depth, src_channel.name))
+             elif src_channel.type == SIGNED:
+-                print '         int%u_t %s;' % (depth, src_channel.name)
++                print('         int%u_t %s;' % (depth, src_channel.name))
+ 
+         # Compute the intermediate unshifted values 
+         for i in range(format.nr_channels()):
+@@ -479,7 +479,7 @@
+                 value = None
+                 
+             if value is not None:
+-                print '         %s = %s;' % (src_channel.name, value)
++                print('         %s = %s;' % (src_channel.name, value))
+                 
+         # Convert, swizzle, and store final values
+         for i in range(4):
+@@ -503,11 +503,11 @@
+                 value = '0'
+             else:
+                 assert False
+-            print '         dst[%u] = %s; /* %s */' % (i, value, 'rgba'[i])
++            print('         dst[%u] = %s; /* %s */' % (i, value, 'rgba'[i]))
+         
+     def unpack_from_union(channels, swizzles):
+-        print '         union util_format_%s pixel;' % format.short_name()
+-        print '         memcpy(&pixel, src, sizeof pixel);'
++        print('         union util_format_%s pixel;' % format.short_name())
++        print('         memcpy(&pixel, src, sizeof pixel);')
+     
+         for i in range(4):
+             swizzle = swizzles[i]
+@@ -530,7 +530,7 @@
+                 value = '0'
+             else:
+                 assert False
+-            print '         dst[%u] = %s; /* %s */' % (i, value, 'rgba'[i])
++            print('         dst[%u] = %s; /* %s */' % (i, value, 'rgba'[i]))
+     
+     if format.is_bitmask():
+         print_channels(format, unpack_from_bitmask)
+@@ -551,7 +551,7 @@
+         inv_swizzle = inv_swizzles(swizzles)
+ 
+         depth = format.block_size()
+-        print '         uint%u_t value = 0;' % depth 
++        print('         uint%u_t value = 0;' % depth) 
+ 
+         for i in range(4):
+             dst_channel = channels[i]
+@@ -577,14 +577,14 @@
+                 else:
+                     value = None
+                 if value is not None:
+-                    print '         value |= %s;' % (value)
++                    print('         value |= %s;' % (value))
+                 
+-        print '         *(uint%u_t *)dst = value;' % depth 
++        print('         *(uint%u_t *)dst = value;' % depth) 
+ 
+     def pack_into_union(channels, swizzles):
+         inv_swizzle = inv_swizzles(swizzles)
+ 
+-        print '         union util_format_%s pixel;' % format.short_name()
++        print('         union util_format_%s pixel;' % format.short_name())
+     
+         for i in range(4):
+             dst_channel = channels[i]
+@@ -600,9 +600,9 @@
+                                     dst_channel, dst_native_type, 
+                                     value, 
+                                     dst_colorspace = dst_colorspace)
+-            print '         pixel.chan.%s = %s;' % (dst_channel.name, value)
+-    
+-        print '         memcpy(dst, &pixel, sizeof pixel);'
++            print('         pixel.chan.%s = %s;' % (dst_channel.name, value))
++    
++        print('         memcpy(dst, &pixel, sizeof pixel);')
+     
+     if format.is_bitmask():
+         print_channels(format, pack_into_bitmask)
+@@ -615,28 +615,28 @@
+ 
+     name = format.short_name()
+ 
+-    print 'static inline void'
+-    print 'util_format_%s_unpack_%s(%s *dst_row, unsigned dst_stride, const uint8_t *src_row, unsigned src_stride, unsigned width, unsigned height)' % (name, dst_suffix, dst_native_type)
+-    print '{'
++    print('static inline void')
++    print('util_format_%s_unpack_%s(%s *dst_row, unsigned dst_stride, const uint8_t *src_row, unsigned src_stride, unsigned width, unsigned height)' % (name, dst_suffix, dst_native_type))
++    print('{')
+ 
+     if is_format_supported(format):
+-        print '   unsigned x, y;'
+-        print '   for(y = 0; y < height; y += %u) {' % (format.block_height,)
+-        print '      %s *dst = dst_row;' % (dst_native_type)
+-        print '      const uint8_t *src = src_row;'
+-        print '      for(x = 0; x < width; x += %u) {' % (format.block_width,)
++        print('   unsigned x, y;')
++        print('   for(y = 0; y < height; y += %u) {' % (format.block_height,))
++        print('      %s *dst = dst_row;' % (dst_native_type))
++        print('      const uint8_t *src = src_row;')
++        print('      for(x = 0; x < width; x += %u) {' % (format.block_width,))
+         
+         generate_unpack_kernel(format, dst_channel, dst_native_type)
+     
+-        print '         src += %u;' % (format.block_size() / 8,)
+-        print '         dst += 4;'
+-        print '      }'
+-        print '      src_row += src_stride;'
+-        print '      dst_row += dst_stride/sizeof(*dst_row);'
+-        print '   }'
+-
+-    print '}'
+-    print
++        print('         src += %u;' % (format.block_size() / 8,))
++        print('         dst += 4;')
++        print('      }')
++        print('      src_row += src_stride;')
++        print('      dst_row += dst_stride/sizeof(*dst_row);')
++        print('   }')
++
++    print('}')
++    print()
+     
+ 
+ def generate_format_pack(format, src_channel, src_native_type, src_suffix):
+@@ -644,28 +644,28 @@
+ 
+     name = format.short_name()
+ 
+-    print 'static inline void'
+-    print 'util_format_%s_pack_%s(uint8_t *dst_row, unsigned dst_stride, const %s *src_row, unsigned src_stride, unsigned width, unsigned height)' % (name, src_suffix, src_native_type)
+-    print '{'
++    print('static inline void')
++    print('util_format_%s_pack_%s(uint8_t *dst_row, unsigned dst_stride, const %s *src_row, unsigned src_stride, unsigned width, unsigned height)' % (name, src_suffix, src_native_type))
++    print('{')
+     
+     if is_format_supported(format):
+-        print '   unsigned x, y;'
+-        print '   for(y = 0; y < height; y += %u) {' % (format.block_height,)
+-        print '      const %s *src = src_row;' % (src_native_type)
+-        print '      uint8_t *dst = dst_row;'
+-        print '      for(x = 0; x < width; x += %u) {' % (format.block_width,)
++        print('   unsigned x, y;')
++        print('   for(y = 0; y < height; y += %u) {' % (format.block_height,))
++        print('      const %s *src = src_row;' % (src_native_type))
++        print('      uint8_t *dst = dst_row;')
++        print('      for(x = 0; x < width; x += %u) {' % (format.block_width,))
+     
+         generate_pack_kernel(format, src_channel, src_native_type)
+             
+-        print '         src += 4;'
+-        print '         dst += %u;' % (format.block_size() / 8,)
+-        print '      }'
+-        print '      dst_row += dst_stride;'
+-        print '      src_row += src_stride/sizeof(*src_row);'
+-        print '   }'
++        print('         src += 4;')
++        print('         dst += %u;' % (format.block_size() / 8,))
++        print('      }')
++        print('      dst_row += dst_stride;')
++        print('      src_row += src_stride/sizeof(*src_row);')
++        print('   }')
+         
+-    print '}'
+-    print
++    print('}')
++    print()
+     
+ 
+ def generate_format_fetch(format, dst_channel, dst_native_type, dst_suffix):
+@@ -673,15 +673,15 @@
+ 
+     name = format.short_name()
+ 
+-    print 'static inline void'
+-    print 'util_format_%s_fetch_%s(%s *dst, const uint8_t *src, unsigned i, unsigned j)' % (name, dst_suffix, dst_native_type)
+-    print '{'
++    print('static inline void')
++    print('util_format_%s_fetch_%s(%s *dst, const uint8_t *src, unsigned i, unsigned j)' % (name, dst_suffix, dst_native_type))
++    print('{')
+ 
+     if is_format_supported(format):
+         generate_unpack_kernel(format, dst_channel, dst_native_type)
+ 
+-    print '}'
+-    print
++    print('}')
++    print()
+ 
+ 
+ def is_format_hand_written(format):
+@@ -689,16 +689,16 @@
+ 
+ 
+ def generate(formats):
+-    print
+-    print '#include "pipe/p_compiler.h"'
+-    print '#include "u_math.h"'
+-    print '#include "u_half.h"'
+-    print '#include "u_format.h"'
+-    print '#include "u_format_other.h"'
+-    print '#include "util/format_srgb.h"'
+-    print '#include "u_format_yuv.h"'
+-    print '#include "u_format_zs.h"'
+-    print
++    print()
++    print('#include "pipe/p_compiler.h"')
++    print('#include "u_math.h"')
++    print('#include "u_half.h"')
++    print('#include "u_format.h"')
++    print('#include "u_format_other.h"')
++    print('#include "util/format_srgb.h"')
++    print('#include "u_format_yuv.h"')
++    print('#include "u_format_zs.h"')
++    print()
+ 
+     for format in formats:
+         if not is_format_hand_written(format):
+--- ./src/gallium/auxiliary/util/u_format_parse.py	(original)
++++ ./src/gallium/auxiliary/util/u_format_parse.py	(refactored)
+@@ -29,9 +29,9 @@
+ '''
+ 
+ 
+-VOID, UNSIGNED, SIGNED, FIXED, FLOAT = range(5)
+-
+-SWIZZLE_X, SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_W, SWIZZLE_0, SWIZZLE_1, SWIZZLE_NONE, = range(7)
++VOID, UNSIGNED, SIGNED, FIXED, FLOAT = list(range(5))
++
++SWIZZLE_X, SWIZZLE_Y, SWIZZLE_Z, SWIZZLE_W, SWIZZLE_0, SWIZZLE_1, SWIZZLE_NONE, = list(range(7))
+ 
+ PLAIN = 'plain'
+ 
+@@ -335,7 +335,7 @@
+         
+         name = fields[0]
+         layout = fields[1]
+-        block_width, block_height = map(int, fields[2:4])
++        block_width, block_height = list(map(int, fields[2:4]))
+         colorspace = fields[9]
+ 
+         le_swizzles = [_swizzle_parse_map[swizzle] for swizzle in fields[8]]
+--- ./src/gallium/auxiliary/util/u_format_table.py	(original)
++++ ./src/gallium/auxiliary/util/u_format_table.py	(refactored)
+@@ -79,22 +79,22 @@
+ 
+ 
+ def write_format_table(formats):
+-    print '/* This file is autogenerated by u_format_table.py from u_format.csv. Do not edit directly. */'
+-    print
++    print('/* This file is autogenerated by u_format_table.py from u_format.csv. Do not edit directly. */')
++    print()
+     # This will print the copyright message on the top of this file
+-    print CopyRight.strip()
+-    print
+-    print '#include "u_format.h"'
+-    print '#include "u_format_s3tc.h"'
+-    print '#include "u_format_rgtc.h"'
+-    print '#include "u_format_latc.h"'
+-    print '#include "u_format_etc.h"'
+-    print
++    print(CopyRight.strip())
++    print()
++    print('#include "u_format.h"')
++    print('#include "u_format_s3tc.h"')
++    print('#include "u_format_rgtc.h"')
++    print('#include "u_format_latc.h"')
++    print('#include "u_format_etc.h"')
++    print()
+     
+     u_format_pack.generate(formats)
+     
+     def do_channel_array(channels, swizzles):
+-        print "   {"
++        print("   {")
+         for i in range(4):
+             channel = channels[i]
+             if i < 3:
+@@ -102,13 +102,13 @@
+             else:
+                 sep = ""
+             if channel.size:
+-                print "      {%s, %s, %s, %u, %u}%s\t/* %s = %s */" % (type_map[channel.type], bool_map(channel.norm), bool_map(channel.pure), channel.size, channel.shift, sep, "xyzw"[i], channel.name)
+-            else:
+-                print "      {0, 0, 0, 0, 0}%s" % (sep,)
+-        print "   },"
++                print("      {%s, %s, %s, %u, %u}%s\t/* %s = %s */" % (type_map[channel.type], bool_map(channel.norm), bool_map(channel.pure), channel.size, channel.shift, sep, "xyzw"[i], channel.name))
++            else:
++                print("      {0, 0, 0, 0, 0}%s" % (sep,))
++        print("   },")
+ 
+     def do_swizzle_array(channels, swizzles):
+-        print "   {"
++        print("   {")
+         for i in range(4):
+             swizzle = swizzles[i]
+             if i < 3:
+@@ -119,102 +119,102 @@
+                 comment = colorspace_channels_map[format.colorspace][i]
+             except (KeyError, IndexError):
+                 comment = 'ignored'
+-            print "      %s%s\t/* %s */" % (swizzle_map[swizzle], sep, comment)
+-        print "   },"
++            print("      %s%s\t/* %s */" % (swizzle_map[swizzle], sep, comment))
++        print("   },")
+ 
+     for format in formats:
+-        print 'const struct util_format_description'
+-        print 'util_format_%s_description = {' % (format.short_name(),)
+-        print "   %s," % (format.name,)
+-        print "   \"%s\"," % (format.name,)
+-        print "   \"%s\"," % (format.short_name(),)
+-        print "   {%u, %u, %u},\t/* block */" % (format.block_width, format.block_height, format.block_size())
+-        print "   %s," % (layout_map(format.layout),)
+-        print "   %u,\t/* nr_channels */" % (format.nr_channels(),)
+-        print "   %s,\t/* is_array */" % (bool_map(format.is_array()),)
+-        print "   %s,\t/* is_bitmask */" % (bool_map(format.is_bitmask()),)
+-        print "   %s,\t/* is_mixed */" % (bool_map(format.is_mixed()),)
++        print('const struct util_format_description')
++        print('util_format_%s_description = {' % (format.short_name(),))
++        print("   %s," % (format.name,))
++        print("   \"%s\"," % (format.name,))
++        print("   \"%s\"," % (format.short_name(),))
++        print("   {%u, %u, %u},\t/* block */" % (format.block_width, format.block_height, format.block_size()))
++        print("   %s," % (layout_map(format.layout),))
++        print("   %u,\t/* nr_channels */" % (format.nr_channels(),))
++        print("   %s,\t/* is_array */" % (bool_map(format.is_array()),))
++        print("   %s,\t/* is_bitmask */" % (bool_map(format.is_bitmask()),))
++        print("   %s,\t/* is_mixed */" % (bool_map(format.is_mixed()),))
+         u_format_pack.print_channels(format, do_channel_array)
+         u_format_pack.print_channels(format, do_swizzle_array)
+-        print "   %s," % (colorspace_map(format.colorspace),)
++        print("   %s," % (colorspace_map(format.colorspace),))
+         access = True
+         if format.layout in ('bptc', 'astc'):
+             access = False
+         if format.layout == 'etc' and format.short_name() != 'etc1_rgb8':
+             access = False
+         if format.colorspace != ZS and not format.is_pure_color() and access:
+-            print "   &util_format_%s_unpack_rgba_8unorm," % format.short_name() 
+-            print "   &util_format_%s_pack_rgba_8unorm," % format.short_name() 
++            print("   &util_format_%s_unpack_rgba_8unorm," % format.short_name()) 
++            print("   &util_format_%s_pack_rgba_8unorm," % format.short_name()) 
+             if format.layout == 's3tc' or format.layout == 'rgtc':
+-                print "   &util_format_%s_fetch_rgba_8unorm," % format.short_name()
+-            else:
+-                print "   NULL, /* fetch_rgba_8unorm */" 
+-            print "   &util_format_%s_unpack_rgba_float," % format.short_name() 
+-            print "   &util_format_%s_pack_rgba_float," % format.short_name() 
+-            print "   &util_format_%s_fetch_rgba_float," % format.short_name()
+-        else:
+-            print "   NULL, /* unpack_rgba_8unorm */" 
+-            print "   NULL, /* pack_rgba_8unorm */" 
+-            print "   NULL, /* fetch_rgba_8unorm */" 
+-            print "   NULL, /* unpack_rgba_float */" 
+-            print "   NULL, /* pack_rgba_float */" 
+-            print "   NULL, /* fetch_rgba_float */" 
++                print("   &util_format_%s_fetch_rgba_8unorm," % format.short_name())
++            else:
++                print("   NULL, /* fetch_rgba_8unorm */") 
++            print("   &util_format_%s_unpack_rgba_float," % format.short_name()) 
++            print("   &util_format_%s_pack_rgba_float," % format.short_name()) 
++            print("   &util_format_%s_fetch_rgba_float," % format.short_name())
++        else:
++            print("   NULL, /* unpack_rgba_8unorm */") 
++            print("   NULL, /* pack_rgba_8unorm */") 
++            print("   NULL, /* fetch_rgba_8unorm */") 
++            print("   NULL, /* unpack_rgba_float */") 
++            print("   NULL, /* pack_rgba_float */") 
++            print("   NULL, /* fetch_rgba_float */") 
+         if format.has_depth():
+-            print "   &util_format_%s_unpack_z_32unorm," % format.short_name() 
+-            print "   &util_format_%s_pack_z_32unorm," % format.short_name() 
+-            print "   &util_format_%s_unpack_z_float," % format.short_name() 
+-            print "   &util_format_%s_pack_z_float," % format.short_name() 
+-        else:
+-            print "   NULL, /* unpack_z_32unorm */" 
+-            print "   NULL, /* pack_z_32unorm */" 
+-            print "   NULL, /* unpack_z_float */" 
+-            print "   NULL, /* pack_z_float */" 
++            print("   &util_format_%s_unpack_z_32unorm," % format.short_name()) 
++            print("   &util_format_%s_pack_z_32unorm," % format.short_name()) 
++            print("   &util_format_%s_unpack_z_float," % format.short_name()) 
++            print("   &util_format_%s_pack_z_float," % format.short_name()) 
++        else:
++            print("   NULL, /* unpack_z_32unorm */") 
++            print("   NULL, /* pack_z_32unorm */") 
++            print("   NULL, /* unpack_z_float */") 
++            print("   NULL, /* pack_z_float */") 
+         if format.has_stencil():
+-            print "   &util_format_%s_unpack_s_8uint," % format.short_name() 
+-            print "   &util_format_%s_pack_s_8uint," % format.short_name() 
+-        else:
+-            print "   NULL, /* unpack_s_8uint */" 
+-            print "   NULL, /* pack_s_8uint */"
++            print("   &util_format_%s_unpack_s_8uint," % format.short_name()) 
++            print("   &util_format_%s_pack_s_8uint," % format.short_name()) 
++        else:
++            print("   NULL, /* unpack_s_8uint */") 
++            print("   NULL, /* pack_s_8uint */")
+         if format.is_pure_unsigned():
+-            print "   &util_format_%s_unpack_unsigned, /* unpack_rgba_uint */" % format.short_name() 
+-            print "   &util_format_%s_pack_unsigned, /* pack_rgba_uint */" % format.short_name()
+-            print "   &util_format_%s_unpack_signed, /* unpack_rgba_sint */" % format.short_name()
+-            print "   &util_format_%s_pack_signed,  /* pack_rgba_sint */" % format.short_name()
+-            print "   &util_format_%s_fetch_unsigned,  /* fetch_rgba_uint */" % format.short_name()
+-            print "   NULL  /* fetch_rgba_sint */"
++            print("   &util_format_%s_unpack_unsigned, /* unpack_rgba_uint */" % format.short_name()) 
++            print("   &util_format_%s_pack_unsigned, /* pack_rgba_uint */" % format.short_name())
++            print("   &util_format_%s_unpack_signed, /* unpack_rgba_sint */" % format.short_name())
++            print("   &util_format_%s_pack_signed,  /* pack_rgba_sint */" % format.short_name())
++            print("   &util_format_%s_fetch_unsigned,  /* fetch_rgba_uint */" % format.short_name())
++            print("   NULL  /* fetch_rgba_sint */")
+         elif format.is_pure_signed():
+-            print "   &util_format_%s_unpack_unsigned, /* unpack_rgba_uint */" % format.short_name()
+-            print "   &util_format_%s_pack_unsigned, /* pack_rgba_uint */" % format.short_name()
+-            print "   &util_format_%s_unpack_signed, /* unpack_rgba_sint */" % format.short_name()
+-            print "   &util_format_%s_pack_signed,  /* pack_rgba_sint */" % format.short_name()
+-            print "   NULL,  /* fetch_rgba_uint */"
+-            print "   &util_format_%s_fetch_signed  /* fetch_rgba_sint */" % format.short_name()
+-        else:
+-            print "   NULL, /* unpack_rgba_uint */" 
+-            print "   NULL, /* pack_rgba_uint */" 
+-            print "   NULL, /* unpack_rgba_sint */" 
+-            print "   NULL, /* pack_rgba_sint */"
+-            print "   NULL, /* fetch_rgba_uint */"
+-            print "   NULL  /* fetch_rgba_sint */"
+-        print "};"
+-        print
++            print("   &util_format_%s_unpack_unsigned, /* unpack_rgba_uint */" % format.short_name())
++            print("   &util_format_%s_pack_unsigned, /* pack_rgba_uint */" % format.short_name())
++            print("   &util_format_%s_unpack_signed, /* unpack_rgba_sint */" % format.short_name())
++            print("   &util_format_%s_pack_signed,  /* pack_rgba_sint */" % format.short_name())
++            print("   NULL,  /* fetch_rgba_uint */")
++            print("   &util_format_%s_fetch_signed  /* fetch_rgba_sint */" % format.short_name())
++        else:
++            print("   NULL, /* unpack_rgba_uint */") 
++            print("   NULL, /* pack_rgba_uint */") 
++            print("   NULL, /* unpack_rgba_sint */") 
++            print("   NULL, /* pack_rgba_sint */")
++            print("   NULL, /* fetch_rgba_uint */")
++            print("   NULL  /* fetch_rgba_sint */")
++        print("};")
++        print()
+         
+-    print "const struct util_format_description *"
+-    print "util_format_description(enum pipe_format format)"
+-    print "{"
+-    print "   if (format >= PIPE_FORMAT_COUNT) {"
+-    print "      return NULL;"
+-    print "   }"
+-    print
+-    print "   switch (format) {"
++    print("const struct util_format_description *")
++    print("util_format_description(enum pipe_format format)")
++    print("{")
++    print("   if (format >= PIPE_FORMAT_COUNT) {")
++    print("      return NULL;")
++    print("   }")
++    print()
++    print("   switch (format) {")
+     for format in formats:
+-        print "   case %s:" % format.name
+-        print "      return &util_format_%s_description;" % (format.short_name(),)
+-    print "   default:"
+-    print "      return NULL;"
+-    print "   }"
+-    print "}"
+-    print
++        print("   case %s:" % format.name)
++        print("      return &util_format_%s_description;" % (format.short_name(),))
++    print("   default:")
++    print("      return NULL;")
++    print("   }")
++    print("}")
++    print()
+ 
+ 
+ def main():
+--- ./src/gallium/docs/source/conf.py	(original)
++++ ./src/gallium/docs/source/conf.py	(refactored)
+@@ -37,8 +37,8 @@
+ master_doc = 'index'
+ 
+ # General information about the project.
+-project = u'Gallium'
+-copyright = u'2009-2012, VMware, X.org, Nouveau'
++project = 'Gallium'
++copyright = '2009-2012, VMware, X.org, Nouveau'
+ 
+ # The version info for the project you're documenting, acts as replacement for
+ # |version| and |release|, also used in various other places throughout the
+@@ -175,8 +175,8 @@
+ # Grouping the document tree into LaTeX files. List of tuples
+ # (source start file, target name, title, author, documentclass [howto/manual]).
+ latex_documents = [
+-  ('index', 'Gallium.tex', u'Gallium Documentation',
+-   u'VMware, X.org, Nouveau', 'manual'),
++  ('index', 'Gallium.tex', 'Gallium Documentation',
++   'VMware, X.org, Nouveau', 'manual'),
+ ]
+ 
+ # The name of an image file (relative to this directory) to place at the top of
+--- ./src/gallium/drivers/freedreno/ir3/ir3_nir_trig.py	(original)
++++ ./src/gallium/drivers/freedreno/ir3/ir3_nir_trig.py	(refactored)
+@@ -27,6 +27,6 @@
+    (('fcos', 'x'), ('fcos', ('fsub', ('fmul', 6.283185, ('ffract', ('fadd', ('fmul', 0.159155, 'x'), 0.5))), 3.141593))),
+ ]
+ 
+-print '#include "ir3_nir.h"'
+-print nir_algebraic.AlgebraicPass("ir3_nir_apply_trig_workarounds",
+-                                  trig_workarounds).render()
++print('#include "ir3_nir.h"')
++print(nir_algebraic.AlgebraicPass("ir3_nir_apply_trig_workarounds",
++                                  trig_workarounds).render())
+--- ./src/gallium/drivers/svga/svgadump/svga_dump.py	(original)
++++ ./src/gallium/drivers/svga/svgadump/svga_dump.py	(refactored)
+@@ -67,17 +67,17 @@
+ 
+     def visit_enumeration(self):
+         if enums:
+-            print '   switch(%s) {' % ("(*cmd)" + self._instance,)
++            print('   switch(%s) {' % ("(*cmd)" + self._instance,))
+             for name, value in self.decl.values:
+-                print '   case %s:' % (name,)
+-                print '      _debug_printf("\\t\\t%s = %s\\n");' % (self._instance, name)
+-                print '      break;'
+-            print '   default:'
+-            print '      _debug_printf("\\t\\t%s = %%i\\n", %s);' % (self._instance, "(*cmd)" + self._instance)
+-            print '      break;'
+-            print '   }'
++                print('   case %s:' % (name,))
++                print('      _debug_printf("\\t\\t%s = %s\\n");' % (self._instance, name))
++                print('      break;')
++            print('   default:')
++            print('      _debug_printf("\\t\\t%s = %%i\\n", %s);' % (self._instance, "(*cmd)" + self._instance))
++            print('      break;')
++            print('   }')
+         else:
+-            print '   _debug_printf("\\t\\t%s = %%i\\n", %s);' % (self._instance, "(*cmd)" + self._instance)
++            print('   _debug_printf("\\t\\t%s = %%i\\n", %s);' % (self._instance, "(*cmd)" + self._instance))
+ 
+ 
+ def dump_decl(instance, decl):
+@@ -153,7 +153,7 @@
+         dump_decl(self.instance, decl)
+ 
+     def print_instance(self, format):
+-        print '   _debug_printf("\\t\\t%s = %s\\n", %s);' % (self.instance, format, "(*cmd)" + self.instance)
++        print('   _debug_printf("\\t\\t%s = %s\\n", %s);' % (self.instance, format, "(*cmd)" + self.instance))
+ 
+ 
+ def dump_type(instance, type_):
+@@ -163,12 +163,12 @@
+ 
+ 
+ def dump_struct(decls, class_):
+-    print 'static void'
+-    print 'dump_%s(const %s *cmd)' % (class_.name, class_.name)
+-    print '{'
++    print('static void')
++    print('dump_%s(const %s *cmd)' % (class_.name, class_.name))
++    print('{')
+     dump_decl('', class_)
+-    print '}'
+-    print ''
++    print('}')
++    print('')
+ 
+ 
+ cmds = [
+@@ -205,48 +205,48 @@
+ ]
+ 
+ def dump_cmds():
+-    print r'''
++    print(r'''
+ void            
+ svga_dump_command(uint32_t cmd_id, const void *data, uint32_t size)
+ {
+    const uint8_t *body = (const uint8_t *)data;
+    const uint8_t *next = body + size;
+-'''
+-    print '   switch(cmd_id) {'
++''')
++    print('   switch(cmd_id) {')
+     indexes = 'ijklmn'
+     for id, header, body, footer in cmds:
+-        print '   case %s:' % id
+-        print '      _debug_printf("\\t%s\\n");' % id
+-        print '      {'
+-        print '         const %s *cmd = (const %s *)body;' % (header, header)
++        print('   case %s:' % id)
++        print('      _debug_printf("\\t%s\\n");' % id)
++        print('      {')
++        print('         const %s *cmd = (const %s *)body;' % (header, header))
+         if len(body):
+-            print '         unsigned ' + ', '.join(indexes[:len(body)]) + ';'
+-        print '         dump_%s(cmd);' % header
+-        print '         body = (const uint8_t *)&cmd[1];'
++            print('         unsigned ' + ', '.join(indexes[:len(body)]) + ';')
++        print('         dump_%s(cmd);' % header)
++        print('         body = (const uint8_t *)&cmd[1];')
+         for i in range(len(body)):
+             struct, count = body[i]
+             idx = indexes[i]
+-            print '         for(%s = 0; %s < cmd->%s; ++%s) {' % (idx, idx, count, idx)
+-            print '            dump_%s((const %s *)body);' % (struct, struct)
+-            print '            body += sizeof(%s);' % struct
+-            print '         }'
++            print('         for(%s = 0; %s < cmd->%s; ++%s) {' % (idx, idx, count, idx))
++            print('            dump_%s((const %s *)body);' % (struct, struct))
++            print('            body += sizeof(%s);' % struct)
++            print('         }')
+         if footer is not None:
+-            print '         while(body + sizeof(%s) <= next) {' % footer
+-            print '            dump_%s((const %s *)body);' % (footer, footer)
+-            print '            body += sizeof(%s);' % footer
+-            print '         }'
++            print('         while(body + sizeof(%s) <= next) {' % footer)
++            print('            dump_%s((const %s *)body);' % (footer, footer))
++            print('            body += sizeof(%s);' % footer)
++            print('         }')
+         if id == 'SVGA_3D_CMD_SHADER_DEFINE':
+-            print '         svga_shader_dump((const uint32_t *)body,'
+-            print '                          (unsigned)(next - body)/sizeof(uint32_t),'
+-            print '                          FALSE);'
+-            print '         body = next;'
+-        print '      }'
+-        print '      break;'
+-    print '   default:'
+-    print '      _debug_printf("\\t0x%08x\\n", cmd_id);'
+-    print '      break;'
+-    print '   }'
+-    print r'''
++            print('         svga_shader_dump((const uint32_t *)body,')
++            print('                          (unsigned)(next - body)/sizeof(uint32_t),')
++            print('                          FALSE);')
++            print('         body = next;')
++        print('      }')
++        print('      break;')
++    print('   default:')
++    print('      _debug_printf("\\t0x%08x\\n", cmd_id);')
++    print('      break;')
++    print('   }')
++    print(r'''
+    while(body + sizeof(uint32_t) <= next) {
+       _debug_printf("\t\t0x%08x\n", *(const uint32_t *)body);
+       body += sizeof(uint32_t);
+@@ -254,8 +254,8 @@
+    while(body + sizeof(uint32_t) <= next)
+       _debug_printf("\t\t0x%02x\n", *body++);
+ }
+-'''
+-    print r'''
++''')
++    print(r'''
+ void            
+ svga_dump_commands(const void *commands, uint32_t size)
+ {
+@@ -288,25 +288,25 @@
+       }
+    }
+ }
+-'''
++''')
+ 
+ def main():
+-    print copyright.strip()
+-    print
+-    print '/**'
+-    print ' * @file'
+-    print ' * Dump SVGA commands.'
+-    print ' *'
+-    print ' * Generated automatically from svga3d_reg.h by svga_dump.py.'
+-    print ' */'
+-    print
+-    print '#include "svga_types.h"'
+-    print '#include "svga_shader_dump.h"'
+-    print '#include "svga3d_reg.h"'
+-    print
+-    print '#include "util/u_debug.h"'
+-    print '#include "svga_dump.h"'
+-    print
++    print(copyright.strip())
++    print()
++    print('/**')
++    print(' * @file')
++    print(' * Dump SVGA commands.')
++    print(' *')
++    print(' * Generated automatically from svga3d_reg.h by svga_dump.py.')
++    print(' */')
++    print()
++    print('#include "svga_types.h"')
++    print('#include "svga_shader_dump.h"')
++    print('#include "svga3d_reg.h"')
++    print()
++    print('#include "util/u_debug.h"')
++    print('#include "svga_dump.h"')
++    print()
+ 
+     config = parser.config_t(
+         include_paths = ['../../../include', '../include'],
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_archrast.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_archrast.py	(refactored)
+@@ -20,7 +20,7 @@
+ # IN THE SOFTWARE.
+ 
+ # Python source
+-from __future__ import print_function
++
+ import os
+ import sys
+ import re
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_backends.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_backends.py	(refactored)
+@@ -22,7 +22,7 @@
+ # Python source
+ # Compatible with Python2.X and Python3.X
+ 
+-from __future__ import print_function
++
+ import itertools
+ import os
+ import sys
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_common.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_common.py	(refactored)
+@@ -20,7 +20,7 @@
+ # IN THE SOFTWARE.
+ 
+ # Python source
+-from __future__ import print_function
++
+ import os
+ import sys
+ import argparse
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_knobs.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_knobs.py	(refactored)
+@@ -20,7 +20,7 @@
+ # IN THE SOFTWARE.
+ 
+ # Python source
+-from __future__ import print_function
++
+ import os
+ import sys
+ import knob_defs
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_llvm_ir_macros.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_llvm_ir_macros.py	(refactored)
+@@ -19,7 +19,7 @@
+ # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ # IN THE SOFTWARE.
+ 
+-from __future__ import print_function
++
+ import os, sys, re
+ from gen_common import MakoTemplateWriter, ArgumentParser
+ from argparse import FileType
+--- ./src/gallium/drivers/swr/rasterizer/codegen/gen_llvm_types.py	(original)
++++ ./src/gallium/drivers/swr/rasterizer/codegen/gen_llvm_types.py	(refactored)
+@@ -19,7 +19,7 @@
+ # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ # IN THE SOFTWARE.
+ 
+-from __future__ import print_function
++
+ import os, sys, re
+ from gen_common import MakoTemplateWriter, ArgumentParser
+ from argparse import FileType
+--- ./src/gallium/tools/trace/diff_state.py	(original)
++++ ./src/gallium/tools/trace/diff_state.py	(refactored)
+@@ -35,7 +35,7 @@
+ def strip_object_hook(obj):
+     if '__class__' in obj:
+         return None
+-    for name in obj.keys():
++    for name in list(obj.keys()):
+         if name.startswith('__') and name.endswith('__'):
+             del obj[name]
+     return obj
+@@ -79,7 +79,7 @@
+     def visitObject(self, node):
+         self.enter_object()
+ 
+-        members = node.keys()
++        members = list(node.keys())
+         members.sort()
+         for i in range(len(members)):
+             name = members[i]
+@@ -147,8 +147,8 @@
+             return False
+         if len(a) != len(b) and not self.ignore_added:
+             return False
+-        ak = a.keys()
+-        bk = b.keys()
++        ak = list(a.keys())
++        bk = list(b.keys())
+         ak.sort()
+         bk.sort()
+         if ak != bk and not self.ignore_added:
+@@ -201,7 +201,7 @@
+             self.dumper.enter_object()
+             names = set(a.keys())
+             if not self.comparer.ignore_added:
+-                names.update(b.keys())
++                names.update(list(b.keys()))
+             names = list(names)
+             names.sort()
+ 
+@@ -247,7 +247,7 @@
+             self.replace(a, b)
+ 
+     def replace(self, a, b):
+-        if isinstance(a, basestring) and isinstance(b, basestring):
++        if isinstance(a, str) and isinstance(b, str):
+             if '\n' in a or '\n' in b:
+                 a = a.splitlines()
+                 b = b.splitlines()
+@@ -276,7 +276,7 @@
+         self.dumper.visit(b)
+ 
+     def isMultilineString(self, value):
+-        return isinstance(value, basestring) and '\n' in value
++        return isinstance(value, str) and '\n' in value
+     
+     def replaceMultilineString(self, a, b):
+         self.dumper.visit(a)
+--- ./src/gallium/tools/trace/dump_state.py	(original)
++++ ./src/gallium/tools/trace/dump_state.py	(refactored)
+@@ -98,7 +98,7 @@
+         serialized.'''
+ 
+         obj = {}
+-        for name, value in self.__dict__.items():
++        for name, value in list(self.__dict__.items()):
+             if not name.startswith('_'):
+                 obj[name] = value
+         return obj
+@@ -472,7 +472,7 @@
+ 
+         count = min(info.count, self.MAX_ELEMENTS)
+         indices = []
+-        for i in xrange(info.start, info.start + count):
++        for i in range(info.start, info.start + count):
+             offset = self._state.index_buffer.offset + i*index_size
+             if offset + index_size > len(data):
+                 index = 0
+@@ -491,7 +491,7 @@
+ 
+         count = min(count, self.MAX_ELEMENTS)
+         vertices = []
+-        for index in xrange(start, start + count):
++        for index in range(start, start + count):
+             if index >= start + 16:
+                 sys.stdout.write('\t...\n')
+                 break
+--- ./src/gallium/tools/trace/model.py	(original)
++++ ./src/gallium/tools/trace/model.py	(refactored)
+@@ -35,9 +35,9 @@
+ import binascii
+ 
+ try:
+-    from cStringIO import StringIO
++    from io import StringIO
+ except ImportError:
+-    from StringIO import StringIO
++    from io import StringIO
+ 
+ import format
+ 
+@@ -177,7 +177,7 @@
+             self.formatter.literal('NULL')
+             return
+ 
+-        if isinstance(node.value, basestring):
++        if isinstance(node.value, str):
+             self.formatter.literal('"' + node.value + '"')
+             return
+ 
+--- ./src/gallium/tools/trace/parse.py	(original)
++++ ./src/gallium/tools/trace/parse.py	(refactored)
+@@ -34,7 +34,7 @@
+ from model import *
+ 
+ 
+-ELEMENT_START, ELEMENT_END, CHARACTER_DATA, EOF = range(4)
++ELEMENT_START, ELEMENT_END, CHARACTER_DATA, EOF = list(range(4))
+ 
+ 
+ class XmlToken:
+@@ -102,7 +102,7 @@
+                 self.tokens.append(token)
+             self.character_data = ''
+     
+-    def next(self):
++    def __next__(self):
+         size = 16*1024
+         while self.index >= len(self.tokens) and not self.final:
+             self.tokens = []
+@@ -112,7 +112,7 @@
+             data = data.rstrip('\0')
+             try:
+                 self.parser.Parse(data, self.final)
+-            except xml.parsers.expat.ExpatError, e:
++            except xml.parsers.expat.ExpatError as e:
+                 #if e.code == xml.parsers.expat.errors.XML_ERROR_NO_ELEMENTS:
+                 if e.code == 3:
+                     pass
+@@ -149,7 +149,7 @@
+         self.consume()
+     
+     def consume(self):
+-        self.token = self.tokenizer.next()
++        self.token = next(self.tokenizer)
+ 
+     def match_element_start(self, name):
+         return self.token.type == ELEMENT_START and self.token.name_or_data == name
+--- ./src/intel/compiler/brw_nir_trig_workarounds.py	(original)
++++ ./src/intel/compiler/brw_nir_trig_workarounds.py	(refactored)
+@@ -38,6 +38,6 @@
+    (('fcos', 'x'), ('fmul', ('fcos', 'x'), 0.99997)),
+ ]
+ 
+-print '#include "brw_nir.h"'
+-print nir_algebraic.AlgebraicPass("brw_nir_apply_trig_workarounds",
+-                                  trig_workarounds).render()
++print('#include "brw_nir.h"')
++print(nir_algebraic.AlgebraicPass("brw_nir_apply_trig_workarounds",
++                                  trig_workarounds).render())
+--- ./src/intel/genxml/gen_bits_header.py	(original)
++++ ./src/intel/genxml/gen_bits_header.py	(refactored)
+@@ -152,7 +152,7 @@
+         '\'': '',
+     }
+ 
+-    for i, j in substitutions.items():
++    for i, j in list(substitutions.items()):
+         name = name.replace(i, j)
+ 
+     return name
+@@ -221,7 +221,7 @@
+ 
+     def iter_prop(self, prop):
+         if prop == 'length':
+-            return self.length_by_gen.iteritems()
++            return iter(self.length_by_gen.items())
+         else:
+             raise ValueError('Invalid property: "{0}"'.format(prop))
+ 
+@@ -254,9 +254,9 @@
+ 
+     def iter_prop(self, prop):
+         if prop == 'bits':
+-            return self.bits_by_gen.iteritems()
++            return iter(self.bits_by_gen.items())
+         elif prop == 'start':
+-            return self.start_by_gen.iteritems()
++            return iter(self.start_by_gen.items())
+         else:
+             raise ValueError('Invalid property: "{0}"'.format(prop))
+ 
+--- ./src/intel/genxml/gen_pack_header.py	(original)
++++ ./src/intel/genxml/gen_pack_header.py	(refactored)
+@@ -194,7 +194,7 @@
+         '\'': '',
+     }
+ 
+-    for i, j in substitutions.items():
++    for i, j in list(substitutions.items()):
+         name = name.replace(i, j)
+ 
+     return name
+@@ -271,9 +271,9 @@
+         elif self.type == 'mbo':
+             return
+         else:
+-            print("#error unhandled type: %s" % self.type)
+-
+-        print("   %-36s %s%s;" % (type, self.name, dim))
++            print(("#error unhandled type: %s" % self.type))
++
++        print(("   %-36s %s%s;" % (type, self.name, dim)))
+ 
+         if len(self.values) > 0 and self.default == None:
+             if self.prefix:
+@@ -282,7 +282,7 @@
+                 prefix = ""
+ 
+         for value in self.values:
+-            print("#define %-40s %d" % (prefix + value.name, value.value))
++            print(("#define %-40s %d" % (prefix + value.name, value.value)))
+ 
+ class Group(object):
+     def __init__(self, parser, parent, start, count, size):
+@@ -363,7 +363,7 @@
+             # Handle MBZ dwords
+             if not index in dwords:
+                 print("")
+-                print("   dw[%d] = 0;" % index)
++                print(("   dw[%d] = 0;" % index))
+                 continue
+ 
+             # For 64 bit dwords, we aliased the two dword entries in the dword
+@@ -382,8 +382,8 @@
+                 name = field.name + field.dim
+                 if field.type in self.parser.structs and field.start % 32 == 0:
+                     print("")
+-                    print("   %s_pack(data, &dw[%d], &values->%s);" %
+-                          (self.parser.gen_prefix(safe_name(field.type)), index, name))
++                    print(("   %s_pack(data, &dw[%d], &values->%s);" %
++                          (self.parser.gen_prefix(safe_name(field.type)), index, name)))
+                     continue
+ 
+             # Pack any fields of struct type first so we have integer values
+@@ -393,9 +393,9 @@
+                 if type(field) is Field and field.type in self.parser.structs:
+                     name = field.name + field.dim
+                     print("")
+-                    print("   uint32_t v%d_%d;" % (index, field_index))
+-                    print("   %s_pack(data, &v%d_%d, &values->%s);" %
+-                          (self.parser.gen_prefix(safe_name(field.type)), index, field_index, name))
++                    print(("   uint32_t v%d_%d;" % (index, field_index)))
++                    print(("   %s_pack(data, &v%d_%d, &values->%s);" %
++                          (self.parser.gen_prefix(safe_name(field.type)), index, field_index, name)))
+                     field_index = field_index + 1
+ 
+             print("")
+@@ -407,10 +407,10 @@
+ 
+             if dw.size == 32 and dw.address == None:
+                 v = None
+-                print("   dw[%d] =" % index)
++                print(("   dw[%d] =" % index))
+             elif len(dw.fields) > address_count:
+                 v = "v%d" % index
+-                print("   const uint%d_t %s =" % (dw.size, v))
++                print(("   const uint%d_t %s =" % (dw.size, v)))
+             else:
+                 v = "0"
+ 
+@@ -457,21 +457,21 @@
+                                               (name, field.type))
+ 
+             if len(non_address_fields) > 0:
+-                print(" |\n".join("      " + f for f in non_address_fields) + ";")
++                print((" |\n".join("      " + f for f in non_address_fields) + ";"))
+ 
+             if dw.size == 32:
+                 if dw.address:
+-                    print("   dw[%d] = __gen_combine_address(data, &dw[%d], values->%s, %s);" % (index, index, dw.address.name, v))
++                    print(("   dw[%d] = __gen_combine_address(data, &dw[%d], values->%s, %s);" % (index, index, dw.address.name, v)))
+                 continue
+ 
+             if dw.address:
+                 v_address = "v%d_address" % index
+-                print("   const uint64_t %s =\n      __gen_combine_address(data, &dw[%d], values->%s, %s);" %
+-                      (v_address, index, dw.address.name, v))
++                print(("   const uint64_t %s =\n      __gen_combine_address(data, &dw[%d], values->%s, %s);" %
++                      (v_address, index, dw.address.name, v)))
+                 v = v_address
+ 
+-            print("   dw[%d] = %s;" % (index, v))
+-            print("   dw[%d] = %s >> 32;" % (index + 1, v))
++            print(("   dw[%d] = %s;" % (index, v)))
++            print(("   dw[%d] = %s >> 32;" % (index + 1, v)))
+ 
+ class Value(object):
+     def __init__(self, attrs):
+@@ -502,7 +502,7 @@
+         if name == "genxml":
+             self.platform = attrs["name"]
+             self.gen = attrs["gen"].replace('.', '')
+-            print(pack_header % {'license': license, 'platform': self.platform, 'guard': self.gen_guard()})
++            print((pack_header % {'license': license, 'platform': self.platform, 'guard': self.gen_guard()}))
+         elif name in ("instruction", "struct", "register"):
+             if name == "instruction":
+                 self.instruction = safe_name(attrs["name"])
+@@ -563,17 +563,17 @@
+             self.emit_enum()
+             self.enum = None
+         elif name == "genxml":
+-            print('#endif /* %s */' % self.gen_guard())
++            print(('#endif /* %s */' % self.gen_guard()))
+ 
+     def emit_template_struct(self, name, group):
+-        print("struct %s {" % self.gen_prefix(name))
++        print(("struct %s {" % self.gen_prefix(name)))
+         group.emit_template_struct("")
+         print("};\n")
+ 
+     def emit_pack_function(self, name, group):
+         name = self.gen_prefix(name)
+-        print("static inline void\n%s_pack(__gen_user_data *data, void * restrict dst,\n%sconst struct %s * restrict values)\n{" %
+-              (name, ' ' * (len(name) + 6), name))
++        print(("static inline void\n%s_pack(__gen_user_data *data, void * restrict dst,\n%sconst struct %s * restrict values)\n{" %
++              (name, ' ' * (len(name) + 6), name)))
+ 
+         # Cast dst to make header C++ friendly
+         print("   uint32_t * restrict dw = (uint32_t * restrict) dst;")
+@@ -585,10 +585,10 @@
+     def emit_instruction(self):
+         name = self.instruction
+         if not self.length == None:
+-            print('#define %-33s %6d' %
+-                  (self.gen_prefix(name + "_length"), self.length))
+-        print('#define %-33s %6d' %
+-              (self.gen_prefix(name + "_length_bias"), self.length_bias))
++            print(('#define %-33s %6d' %
++                  (self.gen_prefix(name + "_length"), self.length)))
++        print(('#define %-33s %6d' %
++              (self.gen_prefix(name + "_length_bias"), self.length_bias)))
+ 
+         default_fields = []
+         for field in self.group.fields:
+@@ -599,8 +599,8 @@
+             default_fields.append("   .%-35s = %6d" % (field.name, field.default))
+ 
+         if default_fields:
+-            print('#define %-40s\\' % (self.gen_prefix(name + '_header')))
+-            print(",  \\\n".join(default_fields))
++            print(('#define %-40s\\' % (self.gen_prefix(name + '_header'))))
++            print((",  \\\n".join(default_fields)))
+             print('')
+ 
+         self.emit_template_struct(self.instruction, self.group)
+@@ -610,12 +610,12 @@
+     def emit_register(self):
+         name = self.register
+         if not self.reg_num == None:
+-            print('#define %-33s 0x%04x' %
+-                  (self.gen_prefix(name + "_num"), self.reg_num))
++            print(('#define %-33s 0x%04x' %
++                  (self.gen_prefix(name + "_num"), self.reg_num)))
+ 
+         if not self.length == None:
+-            print('#define %-33s %6d' %
+-                  (self.gen_prefix(name + "_length"), self.length))
++            print(('#define %-33s %6d' %
++                  (self.gen_prefix(name + "_length"), self.length)))
+ 
+         self.emit_template_struct(self.register, self.group)
+         self.emit_pack_function(self.register, self.group)
+@@ -623,20 +623,20 @@
+     def emit_struct(self):
+         name = self.struct
+         if not self.length == None:
+-            print('#define %-33s %6d' %
+-                  (self.gen_prefix(name + "_length"), self.length))
++            print(('#define %-33s %6d' %
++                  (self.gen_prefix(name + "_length"), self.length)))
+ 
+         self.emit_template_struct(self.struct, self.group)
+         self.emit_pack_function(self.struct, self.group)
+ 
+     def emit_enum(self):
+-        print('enum %s {' % self.gen_prefix(self.enum))
++        print(('enum %s {' % self.gen_prefix(self.enum)))
+         for value in self.values:
+             if self.prefix:
+                 name = self.prefix + "_" + value.name
+             else:
+                 name = value.name
+-            print('   %-36s = %6d,' % (name.upper(), value.value))
++            print(('   %-36s = %6d,' % (name.upper(), value.value)))
+         print('};\n')
+ 
+     def parse(self, filename):
+--- ./src/intel/genxml/gen_zipped_file.py	(original)
++++ ./src/intel/genxml/gen_zipped_file.py	(refactored)
+@@ -22,7 +22,7 @@
+ # IN THE SOFTWARE.
+ #
+ 
+-from __future__ import print_function
++
+ import os
+ import sys
+ import zlib
+--- ./src/intel/isl/gen_format_layout.py	(original)
++++ ./src/intel/isl/gen_format_layout.py	(refactored)
+@@ -21,7 +21,7 @@
+ 
+ """Generates isl_format_layout.c."""
+ 
+-from __future__ import absolute_import, division, print_function
++
+ import argparse
+ import csv
+ import re
+--- ./src/intel/vulkan/anv_entrypoints_gen.py	(original)
++++ ./src/intel/vulkan/anv_entrypoints_gen.py	(refactored)
+@@ -89,7 +89,7 @@
+     % endfor
+     """), output_encoding='utf-8')
+ 
+-TEMPLATE_C = Template(textwrap.dedent(u"""\
++TEMPLATE_C = Template(textwrap.dedent("""\
+     /*
+      * Copyright � 2015 Intel Corporation
+      *
+--- ./src/mapi/mapi_abi.py	(original)
++++ ./src/mapi/mapi_abi.py	(refactored)
+@@ -166,7 +166,7 @@
+             else:
+                 attrs['handcode'] = None
+ 
+-            if entry_dict.has_key(name):
++            if name in entry_dict:
+                 raise Exception('%s is duplicated' % (name))
+ 
+             cols = []
+@@ -178,7 +178,7 @@
+             ent = ABIEntry(cols, attrs, func)
+             entry_dict[ent.name] = ent
+ 
+-    entries = entry_dict.values()
++    entries = list(entry_dict.values())
+     entries.sort()
+ 
+     return entries
+@@ -244,11 +244,11 @@
+             raise Exception('invalid slot in %s' % (line))
+ 
+         ent = ABIEntry(cols, attrs)
+-        if entry_dict.has_key(ent.name):
++        if ent.name in entry_dict:
+             raise Exception('%s is duplicated' % (ent.name))
+         entry_dict[ent.name] = ent
+ 
+-    entries = entry_dict.values()
++    entries = list(entry_dict.values())
+     entries.sort()
+ 
+     return entries
+@@ -260,7 +260,7 @@
+     all_names = []
+     last_slot = entries[-1].slot
+     i = 0
+-    for slot in xrange(last_slot + 1):
++    for slot in range(last_slot + 1):
+         if entries[i].slot != slot:
+             raise Exception('entries are not ordered by slots')
+         if entries[i].alias:
+@@ -570,79 +570,79 @@
+         return "\n".join(asm)
+ 
+     def output_for_lib(self):
+-        print self.c_notice()
++        print(self.c_notice())
+ 
+         if self.c_header:
+-            print
+-            print self.c_header
+-
+-        print
+-        print '#ifdef MAPI_TMP_DEFINES'
+-        print self.c_public_includes()
+-        print
+-        print self.c_public_declarations(self.prefix_lib)
+-        print '#undef MAPI_TMP_DEFINES'
+-        print '#endif /* MAPI_TMP_DEFINES */'
++            print()
++            print(self.c_header)
++
++        print()
++        print('#ifdef MAPI_TMP_DEFINES')
++        print(self.c_public_includes())
++        print()
++        print(self.c_public_declarations(self.prefix_lib))
++        print('#undef MAPI_TMP_DEFINES')
++        print('#endif /* MAPI_TMP_DEFINES */')
+ 
+         if self.lib_need_table_size:
+-            print
+-            print '#ifdef MAPI_TMP_TABLE'
+-            print self.c_mapi_table()
+-            print '#undef MAPI_TMP_TABLE'
+-            print '#endif /* MAPI_TMP_TABLE */'
++            print()
++            print('#ifdef MAPI_TMP_TABLE')
++            print(self.c_mapi_table())
++            print('#undef MAPI_TMP_TABLE')
++            print('#endif /* MAPI_TMP_TABLE */')
+ 
+         if self.lib_need_noop_array:
+-            print
+-            print '#ifdef MAPI_TMP_NOOP_ARRAY'
+-            print '#ifdef DEBUG'
+-            print
+-            print self.c_noop_functions(self.prefix_noop, self.prefix_warn)
+-            print
+-            print 'const mapi_func table_%s_array[] = {' % (self.prefix_noop)
+-            print self.c_noop_initializer(self.prefix_noop, False)
+-            print '};'
+-            print
+-            print '#else /* DEBUG */'
+-            print
+-            print 'const mapi_func table_%s_array[] = {' % (self.prefix_noop)
+-            print self.c_noop_initializer(self.prefix_noop, True)
+-            print '};'
+-            print
+-            print '#endif /* DEBUG */'
+-            print '#undef MAPI_TMP_NOOP_ARRAY'
+-            print '#endif /* MAPI_TMP_NOOP_ARRAY */'
++            print()
++            print('#ifdef MAPI_TMP_NOOP_ARRAY')
++            print('#ifdef DEBUG')
++            print()
++            print(self.c_noop_functions(self.prefix_noop, self.prefix_warn))
++            print()
++            print('const mapi_func table_%s_array[] = {' % (self.prefix_noop))
++            print(self.c_noop_initializer(self.prefix_noop, False))
++            print('};')
++            print()
++            print('#else /* DEBUG */')
++            print()
++            print('const mapi_func table_%s_array[] = {' % (self.prefix_noop))
++            print(self.c_noop_initializer(self.prefix_noop, True))
++            print('};')
++            print()
++            print('#endif /* DEBUG */')
++            print('#undef MAPI_TMP_NOOP_ARRAY')
++            print('#endif /* MAPI_TMP_NOOP_ARRAY */')
+ 
+         if self.lib_need_stubs:
+             pool, pool_offsets = self.c_stub_string_pool()
+-            print
+-            print '#ifdef MAPI_TMP_PUBLIC_STUBS'
+-            print 'static const char public_string_pool[] ='
+-            print pool
+-            print
+-            print 'static const struct mapi_stub public_stubs[] = {'
+-            print self.c_stub_initializer(self.prefix_lib, pool_offsets)
+-            print '};'
+-            print '#undef MAPI_TMP_PUBLIC_STUBS'
+-            print '#endif /* MAPI_TMP_PUBLIC_STUBS */'
++            print()
++            print('#ifdef MAPI_TMP_PUBLIC_STUBS')
++            print('static const char public_string_pool[] =')
++            print(pool)
++            print()
++            print('static const struct mapi_stub public_stubs[] = {')
++            print(self.c_stub_initializer(self.prefix_lib, pool_offsets))
++            print('};')
++            print('#undef MAPI_TMP_PUBLIC_STUBS')
++            print('#endif /* MAPI_TMP_PUBLIC_STUBS */')
+ 
+         if self.lib_need_all_entries:
+-            print
+-            print '#ifdef MAPI_TMP_PUBLIC_ENTRIES'
+-            print self.c_public_dispatches(self.prefix_lib, False)
+-            print
+-            print 'static const mapi_func public_entries[] = {'
+-            print self.c_public_initializer(self.prefix_lib)
+-            print '};'
+-            print '#undef MAPI_TMP_PUBLIC_ENTRIES'
+-            print '#endif /* MAPI_TMP_PUBLIC_ENTRIES */'
+-
+-            print
+-            print '#ifdef MAPI_TMP_STUB_ASM_GCC'
+-            print '__asm__('
+-            print self.c_asm_gcc(self.prefix_lib, False)
+-            print ');'
+-            print '#undef MAPI_TMP_STUB_ASM_GCC'
+-            print '#endif /* MAPI_TMP_STUB_ASM_GCC */'
++            print()
++            print('#ifdef MAPI_TMP_PUBLIC_ENTRIES')
++            print(self.c_public_dispatches(self.prefix_lib, False))
++            print()
++            print('static const mapi_func public_entries[] = {')
++            print(self.c_public_initializer(self.prefix_lib))
++            print('};')
++            print('#undef MAPI_TMP_PUBLIC_ENTRIES')
++            print('#endif /* MAPI_TMP_PUBLIC_ENTRIES */')
++
++            print()
++            print('#ifdef MAPI_TMP_STUB_ASM_GCC')
++            print('__asm__(')
++            print(self.c_asm_gcc(self.prefix_lib, False))
++            print(');')
++            print('#undef MAPI_TMP_STUB_ASM_GCC')
++            print('#endif /* MAPI_TMP_STUB_ASM_GCC */')
+ 
+         if self.lib_need_non_hidden_entries:
+             all_hidden = True
+@@ -651,37 +651,37 @@
+                     all_hidden = False
+                     break
+             if not all_hidden:
+-                print
+-                print '#ifdef MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN'
+-                print self.c_public_dispatches(self.prefix_lib, True)
+-                print
+-                print '/* does not need public_entries */'
+-                print '#undef MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN'
+-                print '#endif /* MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN */'
+-
+-                print
+-                print '#ifdef MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN'
+-                print '__asm__('
+-                print self.c_asm_gcc(self.prefix_lib, True)
+-                print ');'
+-                print '#undef MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN'
+-                print '#endif /* MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN */'
++                print()
++                print('#ifdef MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN')
++                print(self.c_public_dispatches(self.prefix_lib, True))
++                print()
++                print('/* does not need public_entries */')
++                print('#undef MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN')
++                print('#endif /* MAPI_TMP_PUBLIC_ENTRIES_NO_HIDDEN */')
++
++                print()
++                print('#ifdef MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN')
++                print('__asm__(')
++                print(self.c_asm_gcc(self.prefix_lib, True))
++                print(');')
++                print('#undef MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN')
++                print('#endif /* MAPI_TMP_STUB_ASM_GCC_NO_HIDDEN */')
+ 
+     def output_for_app(self):
+-        print self.c_notice()
+-        print
+-        print self.c_private_declarations(self.prefix_app)
+-        print
+-        print '#ifdef API_TMP_DEFINE_SPEC'
+-        print
+-        print 'static const char %s_spec[] =' % (self.prefix_app)
+-        print self.c_mapi_table_spec()
+-        print
+-        print 'static const mapi_proc %s_procs[] = {' % (self.prefix_app)
+-        print self.c_mapi_table_initializer(self.prefix_app)
+-        print '};'
+-        print
+-        print '#endif /* API_TMP_DEFINE_SPEC */'
++        print(self.c_notice())
++        print()
++        print(self.c_private_declarations(self.prefix_app))
++        print()
++        print('#ifdef API_TMP_DEFINE_SPEC')
++        print()
++        print('static const char %s_spec[] =' % (self.prefix_app))
++        print(self.c_mapi_table_spec())
++        print()
++        print('static const mapi_proc %s_procs[] = {' % (self.prefix_app))
++        print(self.c_mapi_table_initializer(self.prefix_app))
++        print('};')
++        print()
++        print('#endif /* API_TMP_DEFINE_SPEC */')
+ 
+ class GLAPIPrinter(ABIPrinter):
+     """OpenGL API Printer"""
+--- ./src/mapi/glapi/gen/glX_XML.py	(original)
++++ ./src/mapi/glapi/gen/glX_XML.py	(refactored)
+@@ -64,7 +64,7 @@
+                 else:
+                     mode = 1
+ 
+-                if not self.functions.has_key(n):
++                if n not in self.functions:
+                     self.functions[ n ] = [c, mode]
+ 
+         return
+@@ -470,7 +470,7 @@
+     def needs_reply(self):
+         try:
+             x = self._needs_reply
+-        except Exception, e:
++        except Exception as e:
+             x = 0
+             if self.return_type != 'void':
+                 x = 1
+@@ -547,13 +547,13 @@
+         return self
+ 
+ 
+-    def next(self):
+-        f = self.iterator.next()
++    def __next__(self):
++        f = next(self.iterator)
+ 
+         if f.client_supported_for_indirect():
+             return f
+         else:
+-            return self.next()
++            return next(self)
+ 
+ 
+ class glx_api(gl_XML.gl_api):
+--- ./src/mapi/glapi/gen/glX_proto_common.py	(original)
++++ ./src/mapi/glapi/gen/glX_proto_common.py	(refactored)
+@@ -80,12 +80,12 @@
+ 
+         compsize = self.size_call(f)
+         if compsize:
+-            print '    const GLuint compsize = %s;' % (compsize)
++            print('    const GLuint compsize = %s;' % (compsize))
+ 
+         if bias:
+-            print '    const GLuint cmdlen = %s - %u;' % (f.command_length(), bias)
++            print('    const GLuint cmdlen = %s - %u;' % (f.command_length(), bias))
+         else:
+-            print '    const GLuint cmdlen = %s;' % (f.command_length())
++            print('    const GLuint cmdlen = %s;' % (f.command_length()))
+ 
+         #print ''
+         return compsize
+--- ./src/mapi/glapi/gen/glX_proto_recv.py	(original)
++++ ./src/mapi/glapi/gen/glX_proto_recv.py	(refactored)
+@@ -42,10 +42,10 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#  include <X11/Xfuncproto.h>'
+-        print ''
+-        print 'struct __GLXclientStateRec;'
+-        print ''
++        print('#  include <X11/Xfuncproto.h>')
++        print('')
++        print('struct __GLXclientStateRec;')
++        print('')
+         return
+ 
+ 
+@@ -53,16 +53,16 @@
+         for func in api.functionIterateAll():
+             if not func.ignore and not func.vectorequiv:
+                 if func.glx_rop:
+-                    print 'extern _X_HIDDEN void __glXDisp_%s(GLbyte * pc);' % (func.name)
+-                    print 'extern _X_HIDDEN _X_COLD void __glXDispSwap_%s(GLbyte * pc);' % (func.name)
++                    print('extern _X_HIDDEN void __glXDisp_%s(GLbyte * pc);' % (func.name))
++                    print('extern _X_HIDDEN _X_COLD void __glXDispSwap_%s(GLbyte * pc);' % (func.name))
+                 elif func.glx_sop or func.glx_vendorpriv:
+-                    print 'extern _X_HIDDEN int __glXDisp_%s(struct __GLXclientStateRec *, GLbyte *);' % (func.name)
+-                    print 'extern _X_HIDDEN _X_COLD int __glXDispSwap_%s(struct __GLXclientStateRec *, GLbyte *);' % (func.name)
++                    print('extern _X_HIDDEN int __glXDisp_%s(struct __GLXclientStateRec *, GLbyte *);' % (func.name))
++                    print('extern _X_HIDDEN _X_COLD int __glXDispSwap_%s(struct __GLXclientStateRec *, GLbyte *);' % (func.name))
+ 
+                     if func.glx_sop and func.glx_vendorpriv:
+                         n = func.glx_vendorpriv_names[0]
+-                        print 'extern _X_HIDDEN int __glXDisp_%s(struct __GLXclientStateRec *, GLbyte *);' % (n)
+-                        print 'extern _X_HIDDEN _X_COLD int __glXDispSwap_%s(struct __GLXclientStateRec *, GLbyte *);' % (n)
++                        print('extern _X_HIDDEN int __glXDisp_%s(struct __GLXclientStateRec *, GLbyte *);' % (n))
++                        print('extern _X_HIDDEN _X_COLD int __glXDispSwap_%s(struct __GLXclientStateRec *, GLbyte *);' % (n))
+ 
+         return
+ 
+@@ -79,24 +79,24 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include <inttypes.h>'
+-        print '#include "glxserver.h"'
+-        print '#include "indirect_size.h"'
+-        print '#include "indirect_size_get.h"'
+-        print '#include "indirect_dispatch.h"'
+-        print '#include "glxbyteorder.h"'
+-        print '#include "indirect_util.h"'
+-        print '#include "singlesize.h"'
+-        print ''
+-        print 'typedef struct {'
+-        print '    __GLX_PIXEL_3D_HDR;'
+-        print '} __GLXpixel3DHeader;'
+-        print ''
+-        print 'extern GLboolean __glXErrorOccured( void );'
+-        print 'extern void __glXClearErrorOccured( void );'
+-        print ''
+-        print 'static const unsigned dummy_answer[2] = {0, 0};'
+-        print ''
++        print('#include <inttypes.h>')
++        print('#include "glxserver.h"')
++        print('#include "indirect_size.h"')
++        print('#include "indirect_size_get.h"')
++        print('#include "indirect_dispatch.h"')
++        print('#include "glxbyteorder.h"')
++        print('#include "indirect_util.h"')
++        print('#include "singlesize.h"')
++        print('')
++        print('typedef struct {')
++        print('    __GLX_PIXEL_3D_HDR;')
++        print('} __GLXpixel3DHeader;')
++        print('')
++        print('extern GLboolean __glXErrorOccured( void );')
++        print('extern void __glXClearErrorOccured( void );')
++        print('')
++        print('static const unsigned dummy_answer[2] = {0, 0};')
++        print('')
+         return
+ 
+ 
+@@ -128,14 +128,14 @@
+             base = '__glXDispSwap'
+ 
+         if f.glx_rop:
+-            print 'void %s_%s(GLbyte * pc)' % (base, name)
+-        else:
+-            print 'int %s_%s(__GLXclientState *cl, GLbyte *pc)' % (base, name)
+-
+-        print '{'
++            print('void %s_%s(GLbyte * pc)' % (base, name))
++        else:
++            print('int %s_%s(__GLXclientState *cl, GLbyte *pc)' % (base, name))
++
++        print('{')
+ 
+         if not f.is_abi():
+-            print '    %s %s = __glGetProcAddress("gl%s");' % (self.fptrType(name), name, name)
++            print('    %s %s = __glGetProcAddress("gl%s");' % (self.fptrType(name), name, name))
+ 
+         if f.glx_rop or f.vectorequiv:
+             self.printRenderFunction(f)
+@@ -143,10 +143,10 @@
+             if len(f.get_images()) == 0: 
+                 self.printSingleFunction(f, name)
+         else:
+-            print "/* Missing GLX protocol for %s. */" % (name)
+-
+-        print '}'
+-        print ''
++            print("/* Missing GLX protocol for %s. */" % (name))
++
++        print('}')
++        print('')
+         return
+ 
+ 
+@@ -170,30 +170,30 @@
+                 if t.glx_name not in already_done:
+                     real_name = self.real_types[t_size]
+ 
+-                    print 'static _X_UNUSED %s' % (t_name)
+-                    print 'bswap_%s(const void * src)' % (t.glx_name)
+-                    print '{'
+-                    print '    union { %s dst; %s ret; } x;' % (real_name, t_name)
+-                    print '    x.dst = bswap_%u(*(%s *) src);' % (t_size * 8, real_name)
+-                    print '    return x.ret;'
+-                    print '}'
+-                    print ''
++                    print('static _X_UNUSED %s' % (t_name))
++                    print('bswap_%s(const void * src)' % (t.glx_name))
++                    print('{')
++                    print('    union { %s dst; %s ret; } x;' % (real_name, t_name))
++                    print('    x.dst = bswap_%u(*(%s *) src);' % (t_size * 8, real_name))
++                    print('    return x.ret;')
++                    print('}')
++                    print('')
+                     already_done.append( t.glx_name )
+ 
+         for bits in [16, 32, 64]:
+-            print 'static void *'
+-            print 'bswap_%u_array(uint%u_t * src, unsigned count)' % (bits, bits)
+-            print '{'
+-            print '    unsigned  i;'
+-            print ''
+-            print '    for (i = 0 ; i < count ; i++) {'
+-            print '        uint%u_t temp = bswap_%u(src[i]);' % (bits, bits)
+-            print '        src[i] = temp;'
+-            print '    }'
+-            print ''
+-            print '    return src;'
+-            print '}'
+-            print ''
++            print('static void *')
++            print('bswap_%u_array(uint%u_t * src, unsigned count)' % (bits, bits))
++            print('{')
++            print('    unsigned  i;')
++            print('')
++            print('    for (i = 0 ; i < count ; i++) {')
++            print('        uint%u_t temp = bswap_%u(src[i]);' % (bits, bits))
++            print('        src[i] = temp;')
++            print('    }')
++            print('')
++            print('    return src;')
++            print('}')
++            print('')
+ 
+ 
+     def fetch_param(self, param):
+@@ -234,7 +234,7 @@
+ 
+             list.append( '%s        %s' % (indent, location) )
+ 
+-        print '%s    %s%s%s(%s);' % (indent, retval_assign, prefix, f.name, string.join(list, ',\n'))
++        print('%s    %s%s%s(%s);' % (indent, retval_assign, prefix, f.name, string.join(list, ',\n')))
+ 
+ 
+     def common_func_print_just_start(self, f, indent):
+@@ -258,7 +258,7 @@
+             # FIXME or something similar.
+ 
+             if param.img_null_flag:
+-                print '%s    const CARD32 ptr_is_null = *(CARD32 *)(pc + %s);' % (indent, param.offset - 4)
++                print('%s    const CARD32 ptr_is_null = *(CARD32 *)(pc + %s);' % (indent, param.offset - 4))
+                 cond = '(ptr_is_null != 0) ? NULL : '
+             else:
+                 cond = ""
+@@ -269,33 +269,33 @@
+             if param.is_image():
+                 offset = f.offset_of( param.name )
+ 
+-                print '%s    %s const %s = (%s) (%s(pc + %s));' % (indent, type_string, param.name, type_string, cond, offset)
++                print('%s    %s const %s = (%s) (%s(pc + %s));' % (indent, type_string, param.name, type_string, cond, offset))
+ 
+                 if param.depth:
+-                    print '%s    __GLXpixel3DHeader * const hdr = (__GLXpixel3DHeader *)(pc);' % (indent)
++                    print('%s    __GLXpixel3DHeader * const hdr = (__GLXpixel3DHeader *)(pc);' % (indent))
+                 else:
+-                    print '%s    __GLXpixelHeader * const hdr = (__GLXpixelHeader *)(pc);' % (indent)
++                    print('%s    __GLXpixelHeader * const hdr = (__GLXpixelHeader *)(pc);' % (indent))
+ 
+                 need_blank = 1
+             elif param.is_counter or param.name in f.count_parameter_list:
+                 location = self.fetch_param(param)
+-                print '%s    const %s %s = %s;' % (indent, type_string, param.name, location)
++                print('%s    const %s %s = %s;' % (indent, type_string, param.name, location))
+                 need_blank = 1
+             elif len(param.count_parameter_list):
+                 if param.size() == 1 and not self.do_swap:
+                     location = self.fetch_param(param)
+-                    print '%s    %s %s = %s%s;' % (indent, type_string, param.name, cond, location)
++                    print('%s    %s %s = %s%s;' % (indent, type_string, param.name, cond, location))
+                 else:
+-                    print '%s    %s %s;' % (indent, type_string, param.name)
++                    print('%s    %s %s;' % (indent, type_string, param.name))
+                 need_blank = 1
+ 
+ 
+ 
+         if need_blank:
+-            print ''
++            print('')
+ 
+         if align64:
+-            print '#ifdef __GLX_ALIGN64'
++            print('#ifdef __GLX_ALIGN64')
+ 
+             if f.has_variable_size_request():
+                 self.emit_packet_size_calculation(f, 4)
+@@ -303,12 +303,12 @@
+             else:
+                 s = str((f.command_fixed_length() + 3) & ~3)
+ 
+-            print '    if ((unsigned long)(pc) & 7) {'
+-            print '        (void) memmove(pc-4, pc, %s);' % (s)
+-            print '        pc -= 4;'
+-            print '    }'
+-            print '#endif'
+-            print ''
++            print('    if ((unsigned long)(pc) & 7) {')
++            print('        (void) memmove(pc-4, pc, %s);' % (s))
++            print('        pc -= 4;')
++            print('    }')
++            print('#endif')
++            print('')
+ 
+ 
+         need_blank = 0
+@@ -333,35 +333,35 @@
+                         x.append( [2, ['SHORT', 'UNSIGNED_SHORT']] )
+                         x.append( [4, ['INT', 'UNSIGNED_INT', 'FLOAT']] )
+ 
+-                        print '    switch(%s) {' % (param.count_parameter_list[0])
++                        print('    switch(%s) {' % (param.count_parameter_list[0]))
+                         for sub in x:
+                             for t_name in sub[1]:
+-                                print '    case GL_%s:' % (t_name)
++                                print('    case GL_%s:' % (t_name))
+ 
+                             if sub[0] == 1:
+-                                print '        %s = (%s) (pc + %s); break;' % (param.name, param.type_string(), o)
++                                print('        %s = (%s) (pc + %s); break;' % (param.name, param.type_string(), o))
+                             else:
+                                 swap_func = self.swap_name(sub[0])
+-                                print '        %s = (%s) %s( (%s *) (pc + %s), %s ); break;' % (param.name, param.type_string(), swap_func, self.real_types[sub[0]], o, count_name)
+-                        print '    default:'
+-                        print '        return;'
+-                        print '    }'
++                                print('        %s = (%s) %s( (%s *) (pc + %s), %s ); break;' % (param.name, param.type_string(), swap_func, self.real_types[sub[0]], o, count_name))
++                        print('    default:')
++                        print('        return;')
++                        print('    }')
+                     else:
+                         swap_func = self.swap_name(type_size)
+                         compsize = self.size_call(f, 1)
+-                        print '    %s = (%s) %s( (%s *) (pc + %s), %s );' % (param.name, param.type_string(), swap_func, self.real_types[type_size], o, compsize)
++                        print('    %s = (%s) %s( (%s *) (pc + %s), %s );' % (param.name, param.type_string(), swap_func, self.real_types[type_size], o, compsize))
+ 
+                     need_blank = 1
+ 
+         else:
+             for param in f.parameterIterateGlxSend():
+                 if param.count_parameter_list:
+-                    print '%s    %s = (%s) (pc + %s);' % (indent, param.name, param.type_string(), param.offset)
++                    print('%s    %s = (%s) (pc + %s);' % (indent, param.name, param.type_string(), param.offset))
+                     need_blank = 1
+ 
+ 
+         if need_blank:
+-            print ''
++            print('')
+ 
+ 
+         return
+@@ -369,29 +369,29 @@
+ 
+     def printSingleFunction(self, f, name):
+         if name not in f.glx_vendorpriv_names:
+-            print '    xGLXSingleReq * const req = (xGLXSingleReq *) pc;'
+-        else:
+-            print '    xGLXVendorPrivateReq * const req = (xGLXVendorPrivateReq *) pc;'
+-
+-        print '    int error;'
++            print('    xGLXSingleReq * const req = (xGLXSingleReq *) pc;')
++        else:
++            print('    xGLXVendorPrivateReq * const req = (xGLXVendorPrivateReq *) pc;')
++
++        print('    int error;')
+ 
+         if self.do_swap:
+-            print '    __GLXcontext * const cx = __glXForceCurrent(cl, bswap_CARD32( &req->contextTag ), &error);'
+-        else:
+-            print '    __GLXcontext * const cx = __glXForceCurrent(cl, req->contextTag, &error);'
+-
+-        print ''
++            print('    __GLXcontext * const cx = __glXForceCurrent(cl, bswap_CARD32( &req->contextTag ), &error);')
++        else:
++            print('    __GLXcontext * const cx = __glXForceCurrent(cl, req->contextTag, &error);')
++
++        print('')
+         if name not in f.glx_vendorpriv_names:
+-            print '    pc += __GLX_SINGLE_HDR_SIZE;'
+-        else:
+-            print '    pc += __GLX_VENDPRIV_HDR_SIZE;'
+-
+-        print '    if ( cx != NULL ) {'
++            print('    pc += __GLX_SINGLE_HDR_SIZE;')
++        else:
++            print('    pc += __GLX_VENDPRIV_HDR_SIZE;')
++
++        print('    if ( cx != NULL ) {')
+         self.common_func_print_just_start(f, "    ")
+ 
+ 
+         if f.return_type != 'void':
+-            print '        %s retval;' % (f.return_type)
++            print('        %s retval;' % (f.return_type))
+             retval_string = "retval"
+             retval_assign = "retval = "
+         else:
+@@ -419,27 +419,27 @@
+ 
+ 
+             if param.count_parameter_list:
+-                print '        const GLuint compsize = %s;' % (self.size_call(f, 1))
+-                print '        %s answerBuffer[200];' %  (answer_type)
+-                print '        %s %s = __glXGetAnswerBuffer(cl, compsize%s, answerBuffer, sizeof(answerBuffer), %u);' % (param.type_string(), param.name, size_scale, type_size )
++                print('        const GLuint compsize = %s;' % (self.size_call(f, 1)))
++                print('        %s answerBuffer[200];' %  (answer_type))
++                print('        %s %s = __glXGetAnswerBuffer(cl, compsize%s, answerBuffer, sizeof(answerBuffer), %u);' % (param.type_string(), param.name, size_scale, type_size ))
+                 answer_string = param.name
+                 answer_count = "compsize"
+ 
+-                print ''
+-                print '        if (%s == NULL) return BadAlloc;' % (param.name)
+-                print '        __glXClearErrorOccured();'
+-                print ''
++                print('')
++                print('        if (%s == NULL) return BadAlloc;' % (param.name))
++                print('        __glXClearErrorOccured();')
++                print('')
+             elif param.counter:
+-                print '        %s answerBuffer[200];' %  (answer_type)
+-                print '        %s %s = __glXGetAnswerBuffer(cl, %s%s, answerBuffer, sizeof(answerBuffer), %u);' % (param.type_string(), param.name, param.counter, size_scale, type_size)
++                print('        %s answerBuffer[200];' %  (answer_type))
++                print('        %s %s = __glXGetAnswerBuffer(cl, %s%s, answerBuffer, sizeof(answerBuffer), %u);' % (param.type_string(), param.name, param.counter, size_scale, type_size))
+                 answer_string = param.name
+                 answer_count = param.counter
+-                print ''
+-                print '        if (%s == NULL) return BadAlloc;' % (param.name)
+-                print '        __glXClearErrorOccured();'
+-                print ''
++                print('')
++                print('        if (%s == NULL) return BadAlloc;' % (param.name))
++                print('        __glXClearErrorOccured();')
++                print('')
+             elif c >= 1:
+-                print '        %s %s[%u];' % (answer_type, param.name, c)
++                print('        %s %s[%u];' % (answer_type, param.name, c))
+                 answer_string = param.name
+                 answer_count = "%u" % (c)
+ 
+@@ -458,21 +458,21 @@
+ 
+                     if type_size > 1:
+                         swap_name = self.swap_name( type_size )
+-                        print '        (void) %s( (uint%u_t *) %s, %s );' % (swap_name, 8 * type_size, param.name, answer_count)
++                        print('        (void) %s( (uint%u_t *) %s, %s );' % (swap_name, 8 * type_size, param.name, answer_count))
+ 
+ 
+                 reply_func = '__glXSendReplySwap'
+             else:
+                 reply_func = '__glXSendReply'
+ 
+-            print '        %s(cl->client, %s, %s, %u, %s, %s);' % (reply_func, answer_string, answer_count, type_size, is_array_string, retval_string)
++            print('        %s(cl->client, %s, %s, %u, %s, %s);' % (reply_func, answer_string, answer_count, type_size, is_array_string, retval_string))
+         #elif f.note_unflushed:
+         #	print '        cx->hasUnflushedCommands = GL_TRUE;'
+ 
+-        print '        error = Success;'
+-        print '    }'
+-        print ''
+-        print '    return error;'
++        print('        error = Success;')
++        print('    }')
++        print('')
++        print('    return error;')
+         return
+ 
+ 
+@@ -501,19 +501,19 @@
+             # the must NEVER be byte-swapped.
+ 
+             if not (img.img_type == "GL_BITMAP" and img.img_format == "GL_COLOR_INDEX"):
+-                print '    glPixelStorei(GL_UNPACK_SWAP_BYTES, hdr->swapBytes);'
+-
+-            print '    glPixelStorei(GL_UNPACK_LSB_FIRST, hdr->lsbFirst);'
+-
+-            print '    glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint) %shdr->rowLength%s);' % (pre, post)
++                print('    glPixelStorei(GL_UNPACK_SWAP_BYTES, hdr->swapBytes);')
++
++            print('    glPixelStorei(GL_UNPACK_LSB_FIRST, hdr->lsbFirst);')
++
++            print('    glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint) %shdr->rowLength%s);' % (pre, post))
+             if img.depth:
+-                print '    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, (GLint) %shdr->imageHeight%s);' % (pre, post)
+-            print '    glPixelStorei(GL_UNPACK_SKIP_ROWS, (GLint) %shdr->skipRows%s);' % (pre, post)
++                print('    glPixelStorei(GL_UNPACK_IMAGE_HEIGHT, (GLint) %shdr->imageHeight%s);' % (pre, post))
++            print('    glPixelStorei(GL_UNPACK_SKIP_ROWS, (GLint) %shdr->skipRows%s);' % (pre, post))
+             if img.depth:
+-                print '    glPixelStorei(GL_UNPACK_SKIP_IMAGES, (GLint) %shdr->skipImages%s);' % (pre, post)
+-            print '    glPixelStorei(GL_UNPACK_SKIP_PIXELS, (GLint) %shdr->skipPixels%s);' % (pre, post)
+-            print '    glPixelStorei(GL_UNPACK_ALIGNMENT, (GLint) %shdr->alignment%s);' % (pre, post)
+-            print ''
++                print('    glPixelStorei(GL_UNPACK_SKIP_IMAGES, (GLint) %shdr->skipImages%s);' % (pre, post))
++            print('    glPixelStorei(GL_UNPACK_SKIP_PIXELS, (GLint) %shdr->skipPixels%s);' % (pre, post))
++            print('    glPixelStorei(GL_UNPACK_ALIGNMENT, (GLint) %shdr->alignment%s);' % (pre, post))
++            print('')
+ 
+ 
+         self.emit_function_call(f, "", "")
+--- ./src/mapi/glapi/gen/glX_proto_send.py	(original)
++++ ./src/mapi/glapi/gen/glX_proto_send.py	(refactored)
+@@ -163,58 +163,58 @@
+         return
+ 
+     def printRealHeader(self):
+-        print ''
+-        print '#include <GL/gl.h>'
+-        print '#include "indirect.h"'
+-        print '#include "glxclient.h"'
+-        print '#include "indirect_size.h"'
+-        print '#include "glapi.h"'
+-        print '#include <GL/glxproto.h>'
+-        print '#include <X11/Xlib-xcb.h>'
+-        print '#include <xcb/xcb.h>'
+-        print '#include <xcb/glx.h>'
+-        print '#include <limits.h>'
+-
+-        print ''
++        print('')
++        print('#include <GL/gl.h>')
++        print('#include "indirect.h"')
++        print('#include "glxclient.h"')
++        print('#include "indirect_size.h"')
++        print('#include "glapi.h"')
++        print('#include <GL/glxproto.h>')
++        print('#include <X11/Xlib-xcb.h>')
++        print('#include <xcb/xcb.h>')
++        print('#include <xcb/glx.h>')
++        print('#include <limits.h>')
++
++        print('')
+         self.printFastcall()
+         self.printNoinline()
+-        print ''
+-
+-        print 'static _X_INLINE int safe_add(int a, int b)'
+-        print '{'
+-        print '    if (a < 0 || b < 0) return -1;'
+-        print '    if (INT_MAX - a < b) return -1;'
+-        print '    return a + b;'
+-        print '}'
+-        print 'static _X_INLINE int safe_mul(int a, int b)'
+-        print '{'
+-        print '    if (a < 0 || b < 0) return -1;'
+-        print '    if (a == 0 || b == 0) return 0;'
+-        print '    if (a > INT_MAX / b) return -1;'
+-        print '    return a * b;'
+-        print '}'
+-        print 'static _X_INLINE int safe_pad(int a)'
+-        print '{'
+-        print '    int ret;'
+-        print '    if (a < 0) return -1;'
+-        print '    if ((ret = safe_add(a, 3)) < 0) return -1;'
+-        print '    return ret & (GLuint)~3;'
+-        print '}'
+-        print ''
+-
+-        print '#ifndef __GNUC__'
+-        print '#  define __builtin_expect(x, y) x'
+-        print '#endif'
+-        print ''
+-        print '/* If the size and opcode values are known at compile-time, this will, on'
+-        print ' * x86 at least, emit them with a single instruction.'
+-        print ' */'
+-        print '#define emit_header(dest, op, size)            \\'
+-        print '    do { union { short s[2]; int i; } temp;    \\'
+-        print '         temp.s[0] = (size); temp.s[1] = (op); \\'
+-        print '         *((int *)(dest)) = temp.i; } while(0)'
+-        print ''
+-        print """NOINLINE CARD32
++        print('')
++
++        print('static _X_INLINE int safe_add(int a, int b)')
++        print('{')
++        print('    if (a < 0 || b < 0) return -1;')
++        print('    if (INT_MAX - a < b) return -1;')
++        print('    return a + b;')
++        print('}')
++        print('static _X_INLINE int safe_mul(int a, int b)')
++        print('{')
++        print('    if (a < 0 || b < 0) return -1;')
++        print('    if (a == 0 || b == 0) return 0;')
++        print('    if (a > INT_MAX / b) return -1;')
++        print('    return a * b;')
++        print('}')
++        print('static _X_INLINE int safe_pad(int a)')
++        print('{')
++        print('    int ret;')
++        print('    if (a < 0) return -1;')
++        print('    if ((ret = safe_add(a, 3)) < 0) return -1;')
++        print('    return ret & (GLuint)~3;')
++        print('}')
++        print('')
++
++        print('#ifndef __GNUC__')
++        print('#  define __builtin_expect(x, y) x')
++        print('#endif')
++        print('')
++        print('/* If the size and opcode values are known at compile-time, this will, on')
++        print(' * x86 at least, emit them with a single instruction.')
++        print(' */')
++        print('#define emit_header(dest, op, size)            \\')
++        print('    do { union { short s[2]; int i; } temp;    \\')
++        print('         temp.s[0] = (size); temp.s[1] = (op); \\')
++        print('         *((int *)(dest)) = temp.i; } while(0)')
++        print('')
++        print("""NOINLINE CARD32
+ __glXReadReply( Display *dpy, size_t size, void * dest, GLboolean reply_is_always_array )
+ {
+     xGLXSingleReply reply;
+@@ -326,7 +326,7 @@
+ #define default_pixel_store_3D_size 36
+ #define default_pixel_store_4D      (__glXDefaultPixelStore+0)
+ #define default_pixel_store_4D_size 36
+-"""
++""")
+ 
+         for size in self.generic_sizes:
+             self.print_generic_function(size)
+@@ -381,20 +381,20 @@
+                 if func.has_different_protocol(n):
+                     procs[n] = func.static_glx_name(n)
+ 
+-        print """
++        print("""
+ #ifdef GLX_INDIRECT_RENDERING
+ 
+ static const struct proc_pair
+ {
+    const char *name;
+    _glapi_proc proc;
+-} proc_pairs[%d] = {""" % len(procs)
+-        names = procs.keys()
++} proc_pairs[%d] = {""" % len(procs))
++        names = list(procs.keys())
+         names.sort()
+-        for i in xrange(len(names)):
++        for i in range(len(names)):
+             comma = ',' if i < len(names) - 1 else ''
+-            print '   { "%s", (_glapi_proc) gl%s }%s' % (names[i], procs[names[i]], comma)
+-        print """};
++            print('   { "%s", (_glapi_proc) gl%s }%s' % (names[i], procs[names[i]], comma))
++        print("""};
+ 
+ static int
+ __indirect_get_proc_compare(const void *key, const void *memb)
+@@ -419,16 +419,16 @@
+ }
+ 
+ #endif /* GLX_INDIRECT_RENDERING */
+-"""
++""")
+         return
+ 
+ 
+     def printFunction(self, func, name):
+         footer = '}\n'
+         if func.glx_rop == ~0:
+-            print 'static %s' % (func.return_type)
+-            print '%s( unsigned opcode, unsigned dim, %s )' % (func.name, func.get_parameter_string())
+-            print '{'
++            print('static %s' % (func.return_type))
++            print('%s( unsigned opcode, unsigned dim, %s )' % (func.name, func.get_parameter_string()))
++            print('{')
+         else:
+             if func.has_different_protocol(name):
+                 if func.return_type == "void":
+@@ -437,27 +437,27 @@
+                     ret_string = "return "
+ 
+                 func_name = func.static_glx_name(name)
+-                print '#define %s %d' % (func.opcode_vendor_name(name), func.glx_vendorpriv)
+-                print '%s gl%s(%s)' % (func.return_type, func_name, func.get_parameter_string())
+-                print '{'
+-                print '    struct glx_context * const gc = __glXGetCurrentContext();'
+-                print ''
+-                print '#if defined(GLX_DIRECT_RENDERING) && !defined(GLX_USE_APPLEGL)'
+-                print '    if (gc->isDirect) {'
+-                print '        const _glapi_proc *const disp_table = (_glapi_proc *)GET_DISPATCH();'
+-                print '        PFNGL%sPROC p =' % (name.upper())
+-                print '            (PFNGL%sPROC) disp_table[%d];' % (name.upper(), func.offset)
+-                print '    %sp(%s);' % (ret_string, func.get_called_parameter_string())
+-                print '    } else'
+-                print '#endif'
+-                print '    {'
++                print('#define %s %d' % (func.opcode_vendor_name(name), func.glx_vendorpriv))
++                print('%s gl%s(%s)' % (func.return_type, func_name, func.get_parameter_string()))
++                print('{')
++                print('    struct glx_context * const gc = __glXGetCurrentContext();')
++                print('')
++                print('#if defined(GLX_DIRECT_RENDERING) && !defined(GLX_USE_APPLEGL)')
++                print('    if (gc->isDirect) {')
++                print('        const _glapi_proc *const disp_table = (_glapi_proc *)GET_DISPATCH();')
++                print('        PFNGL%sPROC p =' % (name.upper()))
++                print('            (PFNGL%sPROC) disp_table[%d];' % (name.upper(), func.offset))
++                print('    %sp(%s);' % (ret_string, func.get_called_parameter_string()))
++                print('    } else')
++                print('#endif')
++                print('    {')
+ 
+                 footer = '}\n}\n'
+             else:
+-                print '#define %s %d' % (func.opcode_name(), func.opcode_value())
+-
+-                print '%s __indirect_gl%s(%s)' % (func.return_type, name, func.get_parameter_string())
+-                print '{'
++                print('#define %s %d' % (func.opcode_name(), func.opcode_value()))
++
++                print('%s __indirect_gl%s(%s)' % (func.return_type, name, func.get_parameter_string()))
++                print('{')
+ 
+ 
+         if func.glx_rop != 0 or func.vectorequiv != None:
+@@ -469,15 +469,15 @@
+             self.printSingleFunction(func, name)
+             pass
+         else:
+-            print "/* Missing GLX protocol for %s. */" % (name)
+-
+-        print footer
++            print("/* Missing GLX protocol for %s. */" % (name))
++
++        print(footer)
+         return
+ 
+ 
+     def print_generic_function(self, n):
+         size = (n + 3) & ~3
+-        print """static FASTCALL NOINLINE void
++        print("""static FASTCALL NOINLINE void
+ generic_%u_byte( GLint rop, const void * ptr )
+ {
+     struct glx_context * const gc = __glXGetCurrentContext();
+@@ -488,7 +488,7 @@
+     gc->pc += cmdlen;
+     if (__builtin_expect(gc->pc > gc->limit, 0)) { (void) __glXFlushRenderBuffer(gc, gc->pc); }
+ }
+-""" % (n, size + 4, size)
++""" % (n, size + 4, size))
+         return
+ 
+ 
+@@ -499,14 +499,14 @@
+             src_ptr = "&" + p.name
+ 
+         if p.is_padding:
+-            print '(void) memset((void *)(%s + %u), 0, %s);' \
+-                % (pc, p.offset + adjust, p.size_string() )
++            print('(void) memset((void *)(%s + %u), 0, %s);' \
++                % (pc, p.offset + adjust, p.size_string() ))
+         elif not extra_offset:
+-            print '(void) memcpy((void *)(%s + %u), (void *)(%s), %s);' \
+-                % (pc, p.offset + adjust, src_ptr, p.size_string() )
+-        else:
+-            print '(void) memcpy((void *)(%s + %u + %s), (void *)(%s), %s);' \
+-                % (pc, p.offset + adjust, extra_offset, src_ptr, p.size_string() )
++            print('(void) memcpy((void *)(%s + %u), (void *)(%s), %s);' \
++                % (pc, p.offset + adjust, src_ptr, p.size_string() ))
++        else:
++            print('(void) memcpy((void *)(%s + %u + %s), (void *)(%s), %s);' \
++                % (pc, p.offset + adjust, extra_offset, src_ptr, p.size_string() ))
+ 
+     def common_emit_args(self, f, pc, adjust, skip_vla):
+         extra_offset = None
+@@ -542,7 +542,7 @@
+                 self.common_emit_one_arg(param, pc, adjust, None)
+ 
+                 if f.pad_after(param):
+-                    print '(void) memcpy((void *)(%s + %u), zero, 4);' % (pc, (param.offset + param.size()) + adjust)
++                    print('(void) memcpy((void *)(%s + %u), zero, 4);' % (pc, (param.offset + param.size()) + adjust))
+ 
+             else:
+                 [dim, width, height, depth, extent] = param.get_dimensions()
+@@ -552,14 +552,14 @@
+                     dim_str = str(dim)
+ 
+                 if param.is_padding:
+-                    print '(void) memset((void *)(%s + %u), 0, %s);' \
+-                    % (pc, (param.offset - 4) + adjust, param.size_string() )
++                    print('(void) memset((void *)(%s + %u), 0, %s);' \
++                    % (pc, (param.offset - 4) + adjust, param.size_string() ))
+ 
+                 if param.img_null_flag:
+                     if large:
+-                        print '(void) memcpy((void *)(%s + %u), zero, 4);' % (pc, (param.offset - 4) + adjust)
++                        print('(void) memcpy((void *)(%s + %u), zero, 4);' % (pc, (param.offset - 4) + adjust))
+                     else:
+-                        print '(void) memcpy((void *)(%s + %u), (void *)((%s == NULL) ? one : zero), 4);' % (pc, (param.offset - 4) + adjust, param.name)
++                        print('(void) memcpy((void *)(%s + %u), (void *)((%s == NULL) ? one : zero), 4);' % (pc, (param.offset - 4) + adjust, param.name))
+ 
+ 
+                 pixHeaderPtr = "%s + %u" % (pc, adjust)
+@@ -571,13 +571,13 @@
+                     else:
+                         condition = 'compsize > 0'
+ 
+-                    print 'if (%s) {' % (condition)
+-                    print '    gc->fillImage(gc, %s, %s, %s, %s, %s, %s, %s, %s, %s);' % (dim_str, width, height, depth, param.img_format, param.img_type, param.name, pcPtr, pixHeaderPtr)
+-                    print '} else {'
+-                    print '    (void) memcpy( %s, default_pixel_store_%uD, default_pixel_store_%uD_size );' % (pixHeaderPtr, dim, dim)
+-                    print '}'
++                    print('if (%s) {' % (condition))
++                    print('    gc->fillImage(gc, %s, %s, %s, %s, %s, %s, %s, %s, %s);' % (dim_str, width, height, depth, param.img_format, param.img_type, param.name, pcPtr, pixHeaderPtr))
++                    print('} else {')
++                    print('    (void) memcpy( %s, default_pixel_store_%uD, default_pixel_store_%uD_size );' % (pixHeaderPtr, dim, dim))
++                    print('}')
+                 else:
+-                    print '__glXSendLargeImage(gc, compsize, %s, %s, %s, %s, %s, %s, %s, %s, %s);' % (dim_str, width, height, depth, param.img_format, param.img_type, param.name, pcPtr, pixHeaderPtr)
++                    print('__glXSendLargeImage(gc, compsize, %s, %s, %s, %s, %s, %s, %s, %s, %s);' % (dim_str, width, height, depth, param.img_format, param.img_type, param.name, pcPtr, pixHeaderPtr))
+ 
+         return
+ 
+@@ -586,16 +586,16 @@
+         if not op_name:
+             op_name = f.opcode_real_name()
+ 
+-        print 'const GLint op = %s;' % (op_name)
+-        print 'const GLuint cmdlenLarge = cmdlen + 4;'
+-        print 'GLubyte * const pc = __glXFlushRenderBuffer(gc, gc->pc);'
+-        print '(void) memcpy((void *)(pc + 0), (void *)(&cmdlenLarge), 4);'
+-        print '(void) memcpy((void *)(pc + 4), (void *)(&op), 4);'
++        print('const GLint op = %s;' % (op_name))
++        print('const GLuint cmdlenLarge = cmdlen + 4;')
++        print('GLubyte * const pc = __glXFlushRenderBuffer(gc, gc->pc);')
++        print('(void) memcpy((void *)(pc + 0), (void *)(&cmdlenLarge), 4);')
++        print('(void) memcpy((void *)(pc + 4), (void *)(&op), 4);')
+         return
+ 
+ 
+     def common_func_print_just_start(self, f, name):
+-        print '    struct glx_context * const gc = __glXGetCurrentContext();'
++        print('    struct glx_context * const gc = __glXGetCurrentContext();')
+ 
+         # The only reason that single and vendor private commands need
+         # a variable called 'dpy' is because they use the SyncHandle
+@@ -613,10 +613,10 @@
+         if not f.glx_rop:
+             for p in f.parameterIterateOutputs():
+                 if p.is_image() and (p.img_format != "GL_COLOR_INDEX" or p.img_type != "GL_BITMAP"):
+-                    print '    const __GLXattribute * const state = gc->client_state_private;'
++                    print('    const __GLXattribute * const state = gc->client_state_private;')
+                     break
+ 
+-            print '    Display * const dpy = gc->currentDpy;'
++            print('    Display * const dpy = gc->currentDpy;')
+             skip_condition = "dpy != NULL"
+         elif f.can_be_large:
+             skip_condition = "gc->currentDpy != NULL"
+@@ -625,35 +625,35 @@
+ 
+ 
+         if f.return_type != 'void':
+-            print '    %s retval = (%s) 0;' % (f.return_type, f.return_type)
++            print('    %s retval = (%s) 0;' % (f.return_type, f.return_type))
+ 
+ 
+         if name != None and name not in f.glx_vendorpriv_names:
+-            print '#ifndef USE_XCB'
++            print('#ifndef USE_XCB')
+         self.emit_packet_size_calculation(f, 0)
+         if name != None and name not in f.glx_vendorpriv_names:
+-            print '#endif'
++            print('#endif')
+ 
+         if f.command_variable_length() != "":
+-            print "    if (0%s < 0) {" % f.command_variable_length()
+-            print "        __glXSetError(gc, GL_INVALID_VALUE);"
++            print("    if (0%s < 0) {" % f.command_variable_length())
++            print("        __glXSetError(gc, GL_INVALID_VALUE);")
+             if f.return_type != 'void':
+-                print "        return 0;"
++                print("        return 0;")
+             else:
+-                print "        return;"
+-            print "    }"
++                print("        return;")
++            print("    }")
+ 
+         condition_list = []
+         for p in f.parameterIterateCounters():
+             condition_list.append( "%s >= 0" % (p.name) )
+             # 'counter' parameters cannot be negative
+-            print "    if (%s < 0) {" % p.name
+-            print "        __glXSetError(gc, GL_INVALID_VALUE);"
++            print("    if (%s < 0) {" % p.name)
++            print("        __glXSetError(gc, GL_INVALID_VALUE);")
+             if f.return_type != 'void':
+-                print "        return 0;"
++                print("        return 0;")
+             else:
+-                print "        return;"
+-            print "    }"
++                print("        return;")
++            print("    }")
+ 
+         if skip_condition:
+             condition_list.append( skip_condition )
+@@ -664,7 +664,7 @@
+             else:
+                 skip_condition = "%s" % (condition_list.pop(0))
+ 
+-            print '    if (__builtin_expect(%s, 1)) {' % (skip_condition)
++            print('    if (__builtin_expect(%s, 1)) {' % (skip_condition))
+             return 1
+         else:
+             return 0
+@@ -674,16 +674,16 @@
+         self.common_func_print_just_start(f, name)
+ 
+         if self.debug:
+-            print '        printf( "Enter %%s...\\n", "gl%s" );' % (f.name)
++            print('        printf( "Enter %%s...\\n", "gl%s" );' % (f.name))
+ 
+         if name not in f.glx_vendorpriv_names:
+ 
+             # XCB specific:
+-            print '#ifdef USE_XCB'
++            print('#ifdef USE_XCB')
+             if self.debug:
+-                print '        printf("\\tUsing XCB.\\n");'
+-            print '        xcb_connection_t *c = XGetXCBConnection(dpy);'
+-            print '        (void) __glXFlushRenderBuffer(gc, gc->pc);'
++                print('        printf("\\tUsing XCB.\\n");')
++            print('        xcb_connection_t *c = XGetXCBConnection(dpy);')
++            print('        (void) __glXFlushRenderBuffer(gc, gc->pc);')
+             xcb_name = 'xcb_glx%s' % convertStringForXCB(name)
+ 
+             iparams=[]
+@@ -710,7 +710,7 @@
+             xcb_request = '%s(%s)' % (xcb_name, ", ".join(["c", "gc->currentContextTag"] + iparams + extra_iparams))
+ 
+             if f.needs_reply():
+-                print '        %s_reply_t *reply = %s_reply(c, %s, NULL);' % (xcb_name, xcb_name, xcb_request)
++                print('        %s_reply_t *reply = %s_reply(c, %s, NULL);' % (xcb_name, xcb_name, xcb_request))
+                 if output:
+                     if output.is_image():
+                         [dim, w, h, d, junk] = output.get_dimensions()
+@@ -721,30 +721,30 @@
+                             if dim < 2:
+                                 h = "1"
+                             else:
+-                                print '        if (%s == 0) { %s = 1; }' % (h, h)
++                                print('        if (%s == 0) { %s = 1; }' % (h, h))
+                             if dim < 3:
+                                 d = "1"
+                             else:
+-                                print '        if (%s == 0) { %s = 1; }' % (d, d)
+-
+-                        print '        __glEmptyImage(gc, 3, %s, %s, %s, %s, %s, %s_data(reply), %s);' % (w, h, d, output.img_format, output.img_type, xcb_name, output.name)
++                                print('        if (%s == 0) { %s = 1; }' % (d, d))
++
++                        print('        __glEmptyImage(gc, 3, %s, %s, %s, %s, %s, %s_data(reply), %s);' % (w, h, d, output.img_format, output.img_type, xcb_name, output.name))
+                     else:
+                         if f.reply_always_array:
+-                            print '        (void)memcpy(%s, %s_data(reply), %s_data_length(reply) * sizeof(%s));' % (output.name, xcb_name, xcb_name, output.get_base_type_string())
++                            print('        (void)memcpy(%s, %s_data(reply), %s_data_length(reply) * sizeof(%s));' % (output.name, xcb_name, xcb_name, output.get_base_type_string()))
+                         else:
+-                            print '        /* the XXX_data_length() xcb function name is misleading, it returns the number */'
+-                            print '        /* of elements, not the length of the data part. A single element is embedded. */'
+-                            print '        if (%s_data_length(reply) == 1)' % (xcb_name)
+-                            print '            (void)memcpy(%s, &reply->datum, sizeof(reply->datum));' % (output.name)
+-                            print '        else'
+-                            print '            (void)memcpy(%s, %s_data(reply), %s_data_length(reply) * sizeof(%s));' % (output.name, xcb_name, xcb_name, output.get_base_type_string())
++                            print('        /* the XXX_data_length() xcb function name is misleading, it returns the number */')
++                            print('        /* of elements, not the length of the data part. A single element is embedded. */')
++                            print('        if (%s_data_length(reply) == 1)' % (xcb_name))
++                            print('            (void)memcpy(%s, &reply->datum, sizeof(reply->datum));' % (output.name))
++                            print('        else')
++                            print('            (void)memcpy(%s, %s_data(reply), %s_data_length(reply) * sizeof(%s));' % (output.name, xcb_name, xcb_name, output.get_base_type_string()))
+ 
+                 if f.return_type != 'void':
+-                    print '        retval = reply->ret_val;'
+-                print '        free(reply);'
++                    print('        retval = reply->ret_val;')
++                print('        free(reply);')
+             else:
+-                print '        ' + xcb_request + ';'
+-            print '#else'
++                print('        ' + xcb_request + ';')
++            print('#else')
+             # End of XCB specific.
+ 
+ 
+@@ -754,9 +754,9 @@
+             pc_decl = "(void)"
+ 
+         if name in f.glx_vendorpriv_names:
+-            print '        %s __glXSetupVendorRequest(gc, %s, %s, cmdlen);' % (pc_decl, f.opcode_real_name(), f.opcode_vendor_name(name))
+-        else:
+-            print '        %s __glXSetupSingleRequest(gc, %s, cmdlen);' % (pc_decl, f.opcode_name())
++            print('        %s __glXSetupVendorRequest(gc, %s, %s, cmdlen);' % (pc_decl, f.opcode_real_name(), f.opcode_vendor_name(name)))
++        else:
++            print('        %s __glXSetupSingleRequest(gc, %s, cmdlen);' % (pc_decl, f.opcode_name()))
+ 
+         self.common_emit_args(f, "pc", 0, 0)
+ 
+@@ -765,12 +765,12 @@
+         for img in images:
+             if img.is_output:
+                 o = f.command_fixed_length() - 4
+-                print '        *(int32_t *)(pc + %u) = 0;' % (o)
++                print('        *(int32_t *)(pc + %u) = 0;' % (o))
+                 if img.img_format != "GL_COLOR_INDEX" or img.img_type != "GL_BITMAP":
+-                    print '        * (int8_t *)(pc + %u) = state->storePack.swapEndian;' % (o)
++                    print('        * (int8_t *)(pc + %u) = state->storePack.swapEndian;' % (o))
+ 
+                 if f.img_reset:
+-                    print '        * (int8_t *)(pc + %u) = %s;' % (o + 1, f.img_reset)
++                    print('        * (int8_t *)(pc + %u) = %s;' % (o + 1, f.img_reset))
+ 
+ 
+         return_name = ''
+@@ -787,9 +787,9 @@
+                 if p.is_image():
+                     [dim, w, h, d, junk] = p.get_dimensions()
+                     if f.dimensions_in_reply:
+-                        print "        __glXReadPixelReply(dpy, gc, %u, 0, 0, 0, %s, %s, %s, GL_TRUE);" % (dim, p.img_format, p.img_type, p.name)
++                        print("        __glXReadPixelReply(dpy, gc, %u, 0, 0, 0, %s, %s, %s, GL_TRUE);" % (dim, p.img_format, p.img_type, p.name))
+                     else:
+-                        print "        __glXReadPixelReply(dpy, gc, %u, %s, %s, %s, %s, %s, %s, GL_FALSE);" % (dim, w, h, d, p.img_format, p.img_type, p.name)
++                        print("        __glXReadPixelReply(dpy, gc, %u, %s, %s, %s, %s, %s, %s, GL_FALSE);" % (dim, w, h, d, p.img_format, p.img_type, p.name))
+ 
+                     got_reply = 1
+                 else:
+@@ -809,7 +809,7 @@
+                     # non-arrays) gives us this.
+ 
+                     s = p.size() / p.get_element_count()
+-                    print "       %s __glXReadReply(dpy, %s, %s, %s);" % (return_str, s, p.name, aa)
++                    print("       %s __glXReadReply(dpy, %s, %s, %s);" % (return_str, s, p.name, aa))
+                     got_reply = 1
+ 
+ 
+@@ -817,30 +817,30 @@
+             # read a NULL reply to get the return value.
+ 
+             if not got_reply:
+-                print "       %s __glXReadReply(dpy, 0, NULL, GL_FALSE);" % (return_str)
++                print("       %s __glXReadReply(dpy, 0, NULL, GL_FALSE);" % (return_str))
+ 
+ 
+         elif self.debug:
+             # Only emit the extra glFinish call for functions
+             # that don't already require a reply from the server.
+-            print '        __indirect_glFinish();'
++            print('        __indirect_glFinish();')
+ 
+         if self.debug:
+-            print '        printf( "Exit %%s.\\n", "gl%s" );' % (name)
+-
+-
+-        print '        UnlockDisplay(dpy); SyncHandle();'
++            print('        printf( "Exit %%s.\\n", "gl%s" );' % (name))
++
++
++        print('        UnlockDisplay(dpy); SyncHandle();')
+ 
+         if name not in f.glx_vendorpriv_names:
+-            print '#endif /* USE_XCB */'
+-
+-        print '    }'
+-        print '    return%s;' % (return_name)
++            print('#endif /* USE_XCB */')
++
++        print('    }')
++        print('    return%s;' % (return_name))
+         return
+ 
+ 
+     def printPixelFunction(self, f):
+-        if self.pixel_stubs.has_key( f.name ):
++        if f.name in self.pixel_stubs:
+             # Normally gl_function::get_parameter_string could be
+             # used.  However, this call needs to have the missing
+             # dimensions (e.g., a fake height value for
+@@ -859,7 +859,7 @@
+                 if f.pad_after(param):
+                     p_string += ", 1"
+ 
+-            print '    %s(%s, %u%s );' % (self.pixel_stubs[f.name] , f.opcode_name(), dim, p_string)
++            print('    %s(%s, %u%s );' % (self.pixel_stubs[f.name] , f.opcode_name(), dim, p_string))
+             return
+ 
+ 
+@@ -870,32 +870,32 @@
+ 
+ 
+         if f.can_be_large:
+-            print 'if (cmdlen <= gc->maxSmallRenderCommandSize) {'
+-            print '    if ( (gc->pc + cmdlen) > gc->bufEnd ) {'
+-            print '        (void) __glXFlushRenderBuffer(gc, gc->pc);'
+-            print '    }'
++            print('if (cmdlen <= gc->maxSmallRenderCommandSize) {')
++            print('    if ( (gc->pc + cmdlen) > gc->bufEnd ) {')
++            print('        (void) __glXFlushRenderBuffer(gc, gc->pc);')
++            print('    }')
+ 
+         if f.glx_rop == ~0:
+             opcode = "opcode"
+         else:
+             opcode = f.opcode_real_name()
+ 
+-        print 'emit_header(gc->pc, %s, cmdlen);' % (opcode)
++        print('emit_header(gc->pc, %s, cmdlen);' % (opcode))
+ 
+         self.pixel_emit_args( f, "gc->pc", 0 )
+-        print 'gc->pc += cmdlen;'
+-        print 'if (gc->pc > gc->limit) { (void) __glXFlushRenderBuffer(gc, gc->pc); }'
++        print('gc->pc += cmdlen;')
++        print('if (gc->pc > gc->limit) { (void) __glXFlushRenderBuffer(gc, gc->pc); }')
+ 
+         if f.can_be_large:
+-            print '}'
+-            print 'else {'
++            print('}')
++            print('else {')
+ 
+             self.large_emit_begin(f, opcode)
+             self.pixel_emit_args(f, "pc", 1)
+ 
+-            print '}'
+-
+-        if trailer: print trailer
++            print('}')
++
++        if trailer: print(trailer)
+         return
+ 
+ 
+@@ -912,7 +912,7 @@
+             if p.is_pointer():
+                 cmdlen = f.command_fixed_length()
+                 if cmdlen in self.generic_sizes:
+-                    print '    generic_%u_byte( %s, %s );' % (cmdlen, f.opcode_real_name(), p.name)
++                    print('    generic_%u_byte( %s, %s );' % (cmdlen, f.opcode_real_name(), p.name))
+                     return
+ 
+         if self.common_func_print_just_start(f, None):
+@@ -921,36 +921,36 @@
+             trailer = None
+ 
+         if self.debug:
+-            print 'printf( "Enter %%s...\\n", "gl%s" );' % (f.name)
++            print('printf( "Enter %%s...\\n", "gl%s" );' % (f.name))
+ 
+         if f.can_be_large:
+-            print 'if (cmdlen <= gc->maxSmallRenderCommandSize) {'
+-            print '    if ( (gc->pc + cmdlen) > gc->bufEnd ) {'
+-            print '        (void) __glXFlushRenderBuffer(gc, gc->pc);'
+-            print '    }'
+-
+-        print 'emit_header(gc->pc, %s, cmdlen);' % (f.opcode_real_name())
++            print('if (cmdlen <= gc->maxSmallRenderCommandSize) {')
++            print('    if ( (gc->pc + cmdlen) > gc->bufEnd ) {')
++            print('        (void) __glXFlushRenderBuffer(gc, gc->pc);')
++            print('    }')
++
++        print('emit_header(gc->pc, %s, cmdlen);' % (f.opcode_real_name()))
+ 
+         self.common_emit_args(f, "gc->pc", 4, 0)
+-        print 'gc->pc += cmdlen;'
+-        print 'if (__builtin_expect(gc->pc > gc->limit, 0)) { (void) __glXFlushRenderBuffer(gc, gc->pc); }'
++        print('gc->pc += cmdlen;')
++        print('if (__builtin_expect(gc->pc > gc->limit, 0)) { (void) __glXFlushRenderBuffer(gc, gc->pc); }')
+ 
+         if f.can_be_large:
+-            print '}'
+-            print 'else {'
++            print('}')
++            print('else {')
+ 
+             self.large_emit_begin(f)
+             self.common_emit_args(f, "pc", 8, 1)
+ 
+             p = f.variable_length_parameter()
+-            print '    __glXSendLargeCommand(gc, pc, %u, %s, %s);' % (p.offset + 8, p.name, p.size_string())
+-            print '}'
++            print('    __glXSendLargeCommand(gc, pc, %u, %s, %s);' % (p.offset + 8, p.name, p.size_string()))
++            print('}')
+ 
+         if self.debug:
+-            print '__indirect_glFinish();'
+-            print 'printf( "Exit %%s.\\n", "gl%s" );' % (f.name)
+-
+-        if trailer: print trailer
++            print('__indirect_glFinish();')
++            print('printf( "Exit %%s.\\n", "gl%s" );' % (f.name))
++
++        if trailer: print(trailer)
+         return
+ 
+ 
+@@ -966,7 +966,7 @@
+ 
+ 
+     def printRealHeader(self):
+-        print """/**
++        print("""/**
+  * \\file indirect_init.c
+  * Initialize indirect rendering dispatch table.
+  *
+@@ -1012,15 +1012,15 @@
+        table[i] = (_glapi_proc) NoOp;
+     }
+ 
+-    /* now, initialize the entries we understand */"""
++    /* now, initialize the entries we understand */""")
+ 
+     def printRealFooter(self):
+-        print """
++        print("""
+     return (struct _glapi_table *) table;
+ }
+ 
+ #endif
+-"""
++""")
+         return
+ 
+ 
+@@ -1034,15 +1034,15 @@
+             for func in api.functionIterateByCategory(name):
+                 if func.client_supported_for_indirect():
+                     if preamble:
+-                        print preamble
++                        print(preamble)
+                         preamble = None
+ 
+                     if func.is_abi():
+-                        print '    table[{offset}] = (_glapi_proc) __indirect_gl{name};'.format(name = func.name, offset = func.offset)
++                        print('    table[{offset}] = (_glapi_proc) __indirect_gl{name};'.format(name = func.name, offset = func.offset))
+                     else:
+-                        print '    o = _glapi_get_proc_offset("gl{0}");'.format(func.name)
+-                        print '    assert(o > 0);'
+-                        print '    table[o] = (_glapi_proc) __indirect_gl{0};'.format(func.name)
++                        print('    o = _glapi_get_proc_offset("gl{0}");'.format(func.name))
++                        print('    assert(o > 0);')
++                        print('    table[o] = (_glapi_proc) __indirect_gl{0};'.format(func.name))
+ 
+         return
+ 
+@@ -1062,18 +1062,18 @@
+ 
+ 
+     def printRealHeader(self):
+-        print """/**
++        print("""/**
+  * \\file
+  * Prototypes for indirect rendering functions.
+  *
+  * \\author Kevin E. Martin <kevin@precisioninsight.com>
+  * \\author Ian Romanick <idr@us.ibm.com>
+  */
+-"""
++""")
+         self.printFastcall()
+         self.printNoinline()
+ 
+-        print """
++        print("""
+ #include <X11/Xfuncproto.h>
+ #include "glxclient.h"
+ 
+@@ -1090,32 +1090,32 @@
+ 
+ extern _X_HIDDEN NOINLINE FASTCALL GLubyte * __glXSetupVendorRequest(
+     struct glx_context * gc, GLint code, GLint vop, GLint cmdlen );
+-"""
++""")
+ 
+ 
+     def printBody(self, api):
+         for func in api.functionIterateGlx():
+             params = func.get_parameter_string()
+ 
+-            print 'extern _X_HIDDEN %s __indirect_gl%s(%s);' % (func.return_type, func.name, params)
++            print('extern _X_HIDDEN %s __indirect_gl%s(%s);' % (func.return_type, func.name, params))
+ 
+             for n in func.entry_points:
+                 if func.has_different_protocol(n):
+                     asdf = func.static_glx_name(n)
+                     if asdf not in func.static_entry_points:
+-                        print 'extern _X_HIDDEN %s gl%s(%s);' % (func.return_type, asdf, params)
++                        print('extern _X_HIDDEN %s gl%s(%s);' % (func.return_type, asdf, params))
+                         # give it a easy-to-remember name
+                         if func.client_handcode:
+-                            print '#define gl_dispatch_stub_%s gl%s' % (n, asdf)
++                            print('#define gl_dispatch_stub_%s gl%s' % (n, asdf))
+                     else:
+-                        print 'GLAPI %s GLAPIENTRY gl%s(%s);' % (func.return_type, asdf, params)
++                        print('GLAPI %s GLAPIENTRY gl%s(%s);' % (func.return_type, asdf, params))
+ 
+                     break
+ 
+-        print ''
+-        print '#ifdef GLX_INDIRECT_RENDERING'
+-        print 'extern _X_HIDDEN void (*__indirect_get_proc_address(const char *name))(void);'
+-        print '#endif'
++        print('')
++        print('#ifdef GLX_INDIRECT_RENDERING')
++        print('extern _X_HIDDEN void (*__indirect_get_proc_address(const char *name))(void);')
++        print('#endif')
+ 
+ 
+ def _parser():
+--- ./src/mapi/glapi/gen/glX_proto_size.py	(original)
++++ ./src/mapi/glapi/gen/glX_proto_size.py	(refactored)
+@@ -69,7 +69,7 @@
+         for enum_name in enum_dict:
+             e = enum_dict[ enum_name ]
+ 
+-            if e.functions.has_key( match_name ):
++            if match_name in e.functions:
+                 [count, mode] = e.functions[ match_name ]
+ 
+                 if mode_set and mode != self.mode:
+@@ -77,11 +77,11 @@
+ 
+                 self.mode = mode
+ 
+-                if self.enums.has_key( e.value ):
++                if e.value in self.enums:
+                     if e.name not in self.enums[ e.value ]:
+                         self.enums[ e.value ].append( e )
+                 else:
+-                    if not self.count.has_key( count ):
++                    if count not in self.count:
+                         self.count[ count ] = []
+ 
+                     self.enums[ e.value ] = [ e ]
+@@ -129,7 +129,7 @@
+         for a in self.enums:
+             count += 1
+ 
+-        if self.count.has_key(-1):
++        if -1 in self.count:
+             return 0
+ 
+         # Determine if there is some mask M, such that M = (2^N) - 1,
+@@ -167,19 +167,19 @@
+                     masked_count[i] = c
+ 
+ 
+-            print '    static const GLushort a[%u] = {' % (mask + 1)
++            print('    static const GLushort a[%u] = {' % (mask + 1))
+             for e in masked_enums:
+-                print '        %s, ' % (masked_enums[e])
+-            print '    };'
+-
+-            print '    static const GLubyte b[%u] = {' % (mask + 1)
++                print('        %s, ' % (masked_enums[e]))
++            print('    };')
++
++            print('    static const GLubyte b[%u] = {' % (mask + 1))
+             for c in masked_count:
+-                print '        %u, ' % (masked_count[c])
+-            print '    };'
+-
+-            print '    const unsigned idx = (e & 0x%02xU);' % (mask)
+-            print ''
+-            print '    return (e == a[idx]) ? (GLint) b[idx] : 0;'
++                print('        %u, ' % (masked_count[c]))
++            print('    };')
++
++            print('    const unsigned idx = (e & 0x%02xU);' % (mask))
++            print('')
++            print('    return (e == a[idx]) ? (GLint) b[idx] : 0;')
+             return 1;
+         else:
+             return 0;
+@@ -189,7 +189,7 @@
+         """Emit the body of the __gl*_size function using a 
+         switch-statement."""
+ 
+-        print '    switch( e ) {'
++        print('    switch( e ) {')
+ 
+         for c in self.count:
+             for e in self.count[c]:
+@@ -206,35 +206,35 @@
+                 for enum_obj in self.enums[e]:
+                     list[ enum_obj.priority() ] = enum_obj.name
+ 
+-                keys = list.keys()
++                keys = list(list.keys())
+                 keys.sort()
+                 for k in keys:
+                     j = list[k]
+                     if first:
+-                        print '        case GL_%s:' % (j)
++                        print('        case GL_%s:' % (j))
+                         first = 0
+                     else:
+-                        print '/*      case GL_%s:*/' % (j)
++                        print('/*      case GL_%s:*/' % (j))
+ 
+             if c == -1:
+-                print '            return __gl%s_variable_size( e );' % (name)
++                print('            return __gl%s_variable_size( e );' % (name))
+             else:
+-                print '            return %u;' % (c)
+-
+-        print '        default: return 0;'
+-        print '    }'
++                print('            return %u;' % (c))
++
++        print('        default: return 0;')
++        print('    }')
+ 
+ 
+     def Print(self, name):
+-        print '_X_INTERNAL PURE FASTCALL GLint'
+-        print '__gl%s_size( GLenum e )' % (name)
+-        print '{'
++        print('_X_INTERNAL PURE FASTCALL GLint')
++        print('__gl%s_size( GLenum e )' % (name))
++        print('{')
+ 
+         if not self.PrintUsingTable():
+             self.PrintUsingSwitch(name)
+ 
+-        print '}'
+-        print ''
++        print('}')
++        print('')
+ 
+ 
+ class glx_server_enum_function(glx_enum_function):
+@@ -273,7 +273,7 @@
+             o = f.offset_of( param_name )
+             foo[o] = param_name
+ 
+-        keys = foo.keys()
++        keys = list(foo.keys())
+         keys.sort()
+         for o in keys:
+             p = f.parameters_by_name[ foo[o] ]
+@@ -282,18 +282,18 @@
+             fixup.append( p.name )
+ 
+ 
+-        print '    GLsizei compsize;'
+-        print ''
++        print('    GLsizei compsize;')
++        print('')
+ 
+         printer.common_emit_fixups(fixup)
+ 
+-        print ''
+-        print '    compsize = __gl%s_size(%s);' % (f.name, string.join(f.count_parameter_list, ","))
++        print('')
++        print('    compsize = __gl%s_size(%s);' % (f.name, string.join(f.count_parameter_list, ",")))
+         p = f.variable_length_parameter()
+-        print '    return safe_pad(%s);' % (p.size_string())
+-
+-        print '}'
+-        print ''
++        print('    return safe_pad(%s);' % (p.size_string()))
++
++        print('}')
++        print('')
+ 
+ 
+ class PrintGlxSizeStubs_common(gl_XML.gl_print_base):
+@@ -313,34 +313,34 @@
+ 
+ class PrintGlxSizeStubs_c(PrintGlxSizeStubs_common):
+     def printRealHeader(self):
+-        print ''
+-        print '#include <X11/Xfuncproto.h>'
+-        print '#include <GL/gl.h>'
++        print('')
++        print('#include <X11/Xfuncproto.h>')
++        print('#include <GL/gl.h>')
+         if self.emit_get:
+-            print '#include "indirect_size_get.h"'
+-            print '#include "glxserver.h"'
+-            print '#include "indirect_util.h"'
+-
+-        print '#include "indirect_size.h"'
+-
+-        print ''
++            print('#include "indirect_size_get.h"')
++            print('#include "glxserver.h"')
++            print('#include "indirect_util.h"')
++
++        print('#include "indirect_size.h"')
++
++        print('')
+         self.printPure()
+-        print ''
++        print('')
+         self.printFastcall()
+-        print ''
+-        print ''
+-        print '#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS'
+-        print '#  define ALIAS2(from,to) \\'
+-        print '    _X_INTERNAL PURE FASTCALL GLint __gl ## from ## _size( GLenum e ) \\'
+-        print '        __attribute__ ((alias( # to )));'
+-        print '#  define ALIAS(from,to) ALIAS2( from, __gl ## to ## _size )'
+-        print '#else'
+-        print '#  define ALIAS(from,to) \\'
+-        print '    _X_INTERNAL PURE FASTCALL GLint __gl ## from ## _size( GLenum e ) \\'
+-        print '    { return __gl ## to ## _size( e ); }'
+-        print '#endif'
+-        print ''
+-        print ''
++        print('')
++        print('')
++        print('#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS')
++        print('#  define ALIAS2(from,to) \\')
++        print('    _X_INTERNAL PURE FASTCALL GLint __gl ## from ## _size( GLenum e ) \\')
++        print('        __attribute__ ((alias( # to )));')
++        print('#  define ALIAS(from,to) ALIAS2( from, __gl ## to ## _size )')
++        print('#else')
++        print('#  define ALIAS(from,to) \\')
++        print('    _X_INTERNAL PURE FASTCALL GLint __gl ## from ## _size( GLenum e ) \\')
++        print('    { return __gl ## to ## _size( e ); }')
++        print('#endif')
++        print('')
++        print('')
+ 
+ 
+     def printBody(self, api):
+@@ -354,7 +354,7 @@
+ 
+             if (ef.is_set() and self.emit_set) or (not ef.is_set() and self.emit_get):
+                 sig = ef.signature()
+-                if enum_sigs.has_key( sig ):
++                if sig in enum_sigs:
+                     aliases.append( [func.name, enum_sigs[ sig ]] )
+                 else:
+                     enum_sigs[ sig ] = func.name
+@@ -362,26 +362,26 @@
+ 
+ 
+         for [alias_name, real_name] in aliases:
+-            print 'ALIAS( %s, %s )' % (alias_name, real_name)
++            print('ALIAS( %s, %s )' % (alias_name, real_name))
+ 
+ 
+ 
+ class PrintGlxSizeStubs_h(PrintGlxSizeStubs_common):
+     def printRealHeader(self):
+-        print """/**
++        print("""/**
+  * \\file
+  * Prototypes for functions used to determine the number of data elements in
+  * various GLX protocol messages.
+  *
+  * \\author Ian Romanick <idr@us.ibm.com>
+  */
+-"""
+-        print '#include <X11/Xfuncproto.h>'
+-        print ''
++""")
++        print('#include <X11/Xfuncproto.h>')
++        print('')
+         self.printPure();
+-        print ''
++        print('')
+         self.printFastcall();
+-        print ''
++        print('')
+ 
+ 
+     def printBody(self, api):
+@@ -391,7 +391,7 @@
+                 continue
+ 
+             if (ef.is_set() and self.emit_set) or (not ef.is_set() and self.emit_get):
+-                print 'extern _X_INTERNAL PURE FASTCALL GLint __gl%s_size(GLenum);' % (func.name)
++                print('extern _X_INTERNAL PURE FASTCALL GLint __gl%s_size(GLenum);' % (func.name))
+ 
+ 
+ class PrintGlxReqSize_common(gl_XML.gl_print_base):
+@@ -415,16 +415,16 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include <X11/Xfuncproto.h>'
+-        print ''
++        print('#include <X11/Xfuncproto.h>')
++        print('')
+         self.printPure()
+-        print ''
++        print('')
+ 
+ 
+     def printBody(self, api):
+         for func in api.functionIterateGlx():
+             if not func.ignore and func.has_variable_size_request():
+-                print 'extern PURE _X_HIDDEN int __glX%sReqSize(const GLbyte *pc, Bool swap, int reqlen);' % (func.name)
++                print('extern PURE _X_HIDDEN int __glX%sReqSize(const GLbyte *pc, Bool swap, int reqlen);' % (func.name))
+ 
+ 
+ class PrintGlxReqSize_c(PrintGlxReqSize_common):
+@@ -441,25 +441,25 @@
+ 
+ 
+     def printRealHeader(self):
+-        print ''
+-        print '#include <GL/gl.h>'
+-        print '#include "glxserver.h"'
+-        print '#include "glxbyteorder.h"'
+-        print '#include "indirect_size.h"'
+-        print '#include "indirect_reqsize.h"'
+-        print ''
+-        print '#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS'
+-        print '#  define ALIAS2(from,to) \\'
+-        print '    GLint __glX ## from ## ReqSize( const GLbyte * pc, Bool swap, int reqlen ) \\'
+-        print '        __attribute__ ((alias( # to )));'
+-        print '#  define ALIAS(from,to) ALIAS2( from, __glX ## to ## ReqSize )'
+-        print '#else'
+-        print '#  define ALIAS(from,to) \\'
+-        print '    GLint __glX ## from ## ReqSize( const GLbyte * pc, Bool swap, int reqlen ) \\'
+-        print '    { return __glX ## to ## ReqSize( pc, swap, reqlen ); }'
+-        print '#endif'
+-        print ''
+-        print ''
++        print('')
++        print('#include <GL/gl.h>')
++        print('#include "glxserver.h"')
++        print('#include "glxbyteorder.h"')
++        print('#include "indirect_size.h"')
++        print('#include "indirect_reqsize.h"')
++        print('')
++        print('#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS')
++        print('#  define ALIAS2(from,to) \\')
++        print('    GLint __glX ## from ## ReqSize( const GLbyte * pc, Bool swap, int reqlen ) \\')
++        print('        __attribute__ ((alias( # to )));')
++        print('#  define ALIAS(from,to) ALIAS2( from, __glX ## to ## ReqSize )')
++        print('#else')
++        print('#  define ALIAS(from,to) \\')
++        print('    GLint __glX ## from ## ReqSize( const GLbyte * pc, Bool swap, int reqlen ) \\')
++        print('    { return __glX ## to ## ReqSize( pc, swap, reqlen ); }')
++        print('#endif')
++        print('')
++        print('')
+ 
+ 
+     def printBody(self, api):
+@@ -475,10 +475,10 @@
+ 
+             sig = ef.signature()
+ 
+-            if not enum_functions.has_key(func.name):
++            if func.name not in enum_functions:
+                 enum_functions[ func.name ] = sig
+ 
+-            if not enum_sigs.has_key( sig ):
++            if sig not in enum_sigs:
+                 enum_sigs[ sig ] = ef
+ 
+ 
+@@ -494,7 +494,7 @@
+             if func.server_handcode: continue
+             if not func.has_variable_size_request(): continue
+ 
+-            if enum_functions.has_key(func.name):
++            if func.name in enum_functions:
+                 sig = enum_functions[func.name]
+                 ef = enum_sigs[ sig ]
+ 
+@@ -511,7 +511,7 @@
+ 
+ 
+         for [alias_name, real_name] in aliases:
+-            print 'ALIAS( %s, %s )' % (alias_name, real_name)
++            print('ALIAS( %s, %s )' % (alias_name, real_name))
+ 
+         return
+ 
+@@ -520,10 +520,10 @@
+         """Utility function to emit conditional byte-swaps."""
+ 
+         if fixup:
+-            print '    if (swap) {'
++            print('    if (swap) {')
+             for name in fixup:
+-                print '        %s = bswap_32(%s);' % (name, name)
+-            print '    }'
++                print('        %s = bswap_32(%s);' % (name, name))
++            print('    }')
+ 
+         return
+ 
+@@ -532,14 +532,14 @@
+         offset = p.offset
+         dst = p.string()
+         src = '(%s *)' % (p.type_string())
+-        print '%-18s = *%11s(%s + %u);' % (dst, src, pc, offset + adjust);
++        print('%-18s = *%11s(%s + %u);' % (dst, src, pc, offset + adjust));
+         return
+ 
+ 
+     def common_func_print_just_header(self, f):
+-        print 'int'
+-        print '__glX%sReqSize( const GLbyte * pc, Bool swap, int reqlen )' % (f.name)
+-        print '{'
++        print('int')
++        print('__glX%sReqSize( const GLbyte * pc, Bool swap, int reqlen )' % (f.name))
++        print('{')
+ 
+ 
+     def printPixelFunction(self, f):
+@@ -548,20 +548,20 @@
+         f.offset_of( f.parameters[0].name )
+         [dim, w, h, d, junk] = f.get_images()[0].get_dimensions()
+ 
+-        print '    GLint row_length   = *  (GLint *)(pc +  4);'
++        print('    GLint row_length   = *  (GLint *)(pc +  4);')
+ 
+         if dim < 3:
+             fixup = ['row_length', 'skip_rows', 'alignment']
+-            print '    GLint image_height = 0;'
+-            print '    GLint skip_images  = 0;'
+-            print '    GLint skip_rows    = *  (GLint *)(pc +  8);'
+-            print '    GLint alignment    = *  (GLint *)(pc + 16);'
++            print('    GLint image_height = 0;')
++            print('    GLint skip_images  = 0;')
++            print('    GLint skip_rows    = *  (GLint *)(pc +  8);')
++            print('    GLint alignment    = *  (GLint *)(pc + 16);')
+         else:
+             fixup = ['row_length', 'image_height', 'skip_rows', 'skip_images', 'alignment']
+-            print '    GLint image_height = *  (GLint *)(pc +  8);'
+-            print '    GLint skip_rows    = *  (GLint *)(pc + 16);'
+-            print '    GLint skip_images  = *  (GLint *)(pc + 20);'
+-            print '    GLint alignment    = *  (GLint *)(pc + 32);'
++            print('    GLint image_height = *  (GLint *)(pc +  8);')
++            print('    GLint skip_rows    = *  (GLint *)(pc + 16);')
++            print('    GLint skip_images  = *  (GLint *)(pc + 20);')
++            print('    GLint alignment    = *  (GLint *)(pc + 32);')
+ 
+         img = f.images[0]
+         for p in f.parameterIterateGlxSend():
+@@ -569,21 +569,21 @@
+                 self.common_emit_one_arg(p, "pc", 0)
+                 fixup.append( p.name )
+ 
+-        print ''
++        print('')
+ 
+         self.common_emit_fixups(fixup)
+ 
+         if img.img_null_flag:
+-            print ''
+-            print '	   if (*(CARD32 *) (pc + %s))' % (img.offset - 4)
+-            print '	       return 0;'
+-
+-        print ''
+-        print '    return __glXImageSize(%s, %s, %s, %s, %s, %s,' % (img.img_format, img.img_type, img.img_target, w, h, d )
+-        print '                          image_height, row_length, skip_images,'
+-        print '                          skip_rows, alignment);'
+-        print '}'
+-        print ''
++            print('')
++            print('	   if (*(CARD32 *) (pc + %s))' % (img.offset - 4))
++            print('	       return 0;')
++
++        print('')
++        print('    return __glXImageSize(%s, %s, %s, %s, %s, %s,' % (img.img_format, img.img_type, img.img_target, w, h, d ))
++        print('                          image_height, row_length, skip_images,')
++        print('                          skip_rows, alignment);')
++        print('}')
++        print('')
+         return
+ 
+ 
+@@ -619,7 +619,7 @@
+         # already be emitted, don't emit this function.  Instead, add
+         # it to the list of function aliases.
+ 
+-        if self.counter_sigs.has_key(sig):
++        if sig in self.counter_sigs:
+             n = self.counter_sigs[sig];
+             alias = [f.name, n]
+         else:
+@@ -632,13 +632,13 @@
+                 self.common_emit_one_arg(p, "pc", 0)
+ 
+ 
+-            print ''
++            print('')
+             self.common_emit_fixups(fixup)
+-            print ''
+-
+-            print '    return safe_pad(%s);' % (size)
+-            print '}'
+-            print ''
++            print('')
++
++            print('    return safe_pad(%s);' % (size))
++            print('}')
++            print('')
+ 
+         return alias
+ 
+--- ./src/mapi/glapi/gen/glX_server_table.py	(original)
++++ ./src/mapi/glapi/gen/glX_server_table.py	(refactored)
+@@ -106,7 +106,7 @@
+                 empty = 0
+ 
+                 for j in range(i, i + op_count):
+-                    if self.functions.has_key(j):
++                    if j in self.functions:
+                         used += 1;
+                     else:
+                         empty += 1;
+@@ -155,7 +155,7 @@
+ 
+     def is_empty_leaf(self, base_opcode, M):
+         for op in range(base_opcode, base_opcode + (1 << M)):
+-            if self.functions.has_key(op):
++            if op in self.functions:
+                 return 0
+                 break
+ 
+@@ -172,8 +172,8 @@
+         if children == []:
+             return
+ 
+-        print '    /* [%u] -> opcode range [%u, %u], node depth %u */' % (base_entry, base_opcode, base_opcode + (1 << remaining_bits), depth)
+-        print '    %u,' % (M)
++        print('    /* [%u] -> opcode range [%u, %u], node depth %u */' % (base_entry, base_opcode, base_opcode + (1 << remaining_bits), depth))
++        print('    %u,' % (M))
+ 
+         base_entry += (1 << M) + 1
+ 
+@@ -182,7 +182,7 @@
+         for child in children:
+             if child[1] == []:
+                 if self.is_empty_leaf(child_base_opcode, child_M):
+-                    print '    EMPTY_LEAF,'
++                    print('    EMPTY_LEAF,')
+                 else:
+                     # Emit the index of the next dispatch
+                     # function.  Then add all the
+@@ -190,10 +190,10 @@
+                     # node to the dispatch function
+                     # lookup table.
+ 
+-                    print '    LEAF(%u),' % (len(self.lookup_table))
++                    print('    LEAF(%u),' % (len(self.lookup_table)))
+ 
+                     for op in range(child_base_opcode, child_base_opcode + (1 << child_M)):
+-                        if self.functions.has_key(op):
++                        if op in self.functions:
+                             func = self.functions[op]
+                             size = func.command_fixed_length()
+ 
+@@ -218,12 +218,12 @@
+ 
+                         self.lookup_table.append(temp)
+             else:
+-                print '    %u,' % (child_index)
++                print('    %u,' % (child_index))
+                 child_index += child[2]
+ 
+             child_base_opcode += 1 << child_M
+ 
+-        print ''
++        print('')
+ 
+         child_index = base_entry
+         for child in children:
+@@ -278,31 +278,31 @@
+ 
+         tree = self.divide_group(0, 0)
+ 
+-        print '/*****************************************************************/'
+-        print '/* tree depth = %u */' % (tree[3])
+-        print 'static const int_fast16_t %s_dispatch_tree[%u] = {' % (self.name_base, tree[2])
++        print('/*****************************************************************/')
++        print('/* tree depth = %u */' % (tree[3]))
++        print('static const int_fast16_t %s_dispatch_tree[%u] = {' % (self.name_base, tree[2]))
+         self.dump_tree(tree, 0, self.max_bits, 0, 1)
+-        print '};\n'
++        print('};\n')
+ 
+         # After dumping the tree, dump the function lookup table.
+ 
+-        print 'static const void *%s_function_table[%u][2] = {' % (self.name_base, len(self.lookup_table))
++        print('static const void *%s_function_table[%u][2] = {' % (self.name_base, len(self.lookup_table)))
+         index = 0
+         for func in self.lookup_table:
+             opcode = func[0]
+             name = func[1]
+             name_swap = func[2]
+ 
+-            print '    /* [% 3u] = %5u */ {%s, %s},' % (index, opcode, name, name_swap)
++            print('    /* [% 3u] = %5u */ {%s, %s},' % (index, opcode, name, name_swap))
+ 
+             index += 1
+ 
+-        print '};\n'
++        print('};\n')
+ 
+         if self.do_size_check:
+             var_table = []
+ 
+-            print 'static const int_fast16_t %s_size_table[%u][2] = {' % (self.name_base, len(self.lookup_table))
++            print('static const int_fast16_t %s_size_table[%u][2] = {' % (self.name_base, len(self.lookup_table)))
+             index = 0
+             var_table = []
+             for func in self.lookup_table:
+@@ -316,31 +316,31 @@
+                 else:
+                     var_offset = "~0"
+ 
+-                print '    /* [%3u] = %5u */ {%3u, %s},' % (index, opcode, fixed, var_offset)
++                print('    /* [%3u] = %5u */ {%3u, %s},' % (index, opcode, fixed, var_offset))
+                 index += 1
+ 
+ 
+-            print '};\n'
+-
+-
+-            print 'static const gl_proto_size_func %s_size_func_table[%u] = {' % (self.name_base, len(var_table))
++            print('};\n')
++
++
++            print('static const gl_proto_size_func %s_size_func_table[%u] = {' % (self.name_base, len(var_table)))
+             for func in var_table:
+-                print '   %s,' % (func)
+-
+-            print '};\n'
+-
+-
+-        print 'const struct __glXDispatchInfo %s_dispatch_info = {' % (self.name_base)
+-        print '    %u,' % (self.max_bits)
+-        print '    %s_dispatch_tree,' % (self.name_base)
+-        print '    %s_function_table,' % (self.name_base)
++                print('   %s,' % (func))
++
++            print('};\n')
++
++
++        print('const struct __glXDispatchInfo %s_dispatch_info = {' % (self.name_base))
++        print('    %u,' % (self.max_bits))
++        print('    %s_dispatch_tree,' % (self.name_base))
++        print('    %s_function_table,' % (self.name_base))
+         if self.do_size_check:
+-            print '    %s_size_table,' % (self.name_base)
+-            print '    %s_size_func_table' % (self.name_base)
++            print('    %s_size_table,' % (self.name_base))
++            print('    %s_size_func_table' % (self.name_base))
+         else:
+-            print '    NULL,'
+-            print '    NULL'
+-        print '};\n'
++            print('    NULL,')
++            print('    NULL')
++        print('};\n')
+         return
+ 
+ 
+@@ -357,13 +357,13 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include <inttypes.h>'
+-        print '#include "glxserver.h"'
+-        print '#include "glxext.h"'
+-        print '#include "indirect_dispatch.h"'
+-        print '#include "indirect_reqsize.h"'
+-        print '#include "indirect_table.h"'
+-        print ''
++        print('#include <inttypes.h>')
++        print('#include "glxserver.h"')
++        print('#include "glxext.h"')
++        print('#include "indirect_dispatch.h"')
++        print('#include "indirect_reqsize.h"')
++        print('#include "indirect_table.h"')
++        print('')
+         return
+ 
+ 
+--- ./src/mapi/glapi/gen/gl_SPARC_asm.py	(original)
++++ ./src/mapi/glapi/gen/gl_SPARC_asm.py	(refactored)
+@@ -39,192 +39,192 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#ifdef __arch64__'
+-        print '#define GL_OFF(N)\t((N) * 8)'
+-        print '#define GL_LL\t\tldx'
+-        print '#define GL_TIE_LD(SYM)\t%tie_ldx(SYM)'
+-        print '#define GL_STACK_SIZE\t128'
+-        print '#else'
+-        print '#define GL_OFF(N)\t((N) * 4)'
+-        print '#define GL_LL\t\tld'
+-        print '#define GL_TIE_LD(SYM)\t%tie_ld(SYM)'
+-        print '#define GL_STACK_SIZE\t64'
+-        print '#endif'
+-        print ''
+-        print '#define GLOBL_FN(x) .globl x ; .type x, @function'
+-        print '#define HIDDEN(x) .hidden x'
+-        print ''
+-        print '\t.register %g2, #scratch'
+-        print '\t.register %g3, #scratch'
+-        print ''
+-        print '\t.text'
+-        print ''
+-        print '\tGLOBL_FN(__glapi_sparc_icache_flush)'
+-        print '\tHIDDEN(__glapi_sparc_icache_flush)'
+-        print '\t.type\t__glapi_sparc_icache_flush, @function'
+-        print '__glapi_sparc_icache_flush: /* %o0 = insn_addr */'
+-        print '\tflush\t%o0'
+-        print '\tretl'
+-        print '\t nop'
+-        print ''
+-        print '\t.align\t32'
+-        print ''
+-        print '\t.type\t__glapi_sparc_get_pc, @function'
+-        print '__glapi_sparc_get_pc:'
+-        print '\tretl'
+-        print '\t add\t%o7, %g2, %g2'
+-        print '\t.size\t__glapi_sparc_get_pc, .-__glapi_sparc_get_pc'
+-        print ''
+-        print '#ifdef GLX_USE_TLS'
+-        print ''
+-        print '\tGLOBL_FN(__glapi_sparc_get_dispatch)'
+-        print '\tHIDDEN(__glapi_sparc_get_dispatch)'
+-        print '__glapi_sparc_get_dispatch:'
+-        print '\tmov\t%o7, %g1'
+-        print '\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2'
+-        print '\tcall\t__glapi_sparc_get_pc'
+-        print '\tadd\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2'
+-        print '\tmov\t%g1, %o7'
+-        print '\tsethi\t%tie_hi22(_glapi_tls_Dispatch), %g1'
+-        print '\tadd\t%g1, %tie_lo10(_glapi_tls_Dispatch), %g1'
+-        print '\tGL_LL\t[%g2 + %g1], %g2, GL_TIE_LD(_glapi_tls_Dispatch)'
+-        print '\tretl'
+-        print '\t mov\t%g2, %o0'
+-        print ''
+-        print '\t.data'
+-        print '\t.align\t32'
+-        print ''
+-        print '\t/* --> sethi %hi(_glapi_tls_Dispatch), %g1 */'
+-        print '\t/* --> or %g1, %lo(_glapi_tls_Dispatch), %g1 */'
+-        print '\tGLOBL_FN(__glapi_sparc_tls_stub)'
+-        print '\tHIDDEN(__glapi_sparc_tls_stub)'
+-        print '__glapi_sparc_tls_stub: /* Call offset in %g3 */'
+-        print '\tmov\t%o7, %g1'
+-        print '\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2'
+-        print '\tcall\t__glapi_sparc_get_pc'
+-        print '\tadd\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2'
+-        print '\tmov\t%g1, %o7'
+-        print '\tsrl\t%g3, 10, %g3'
+-        print '\tsethi\t%tie_hi22(_glapi_tls_Dispatch), %g1'
+-        print '\tadd\t%g1, %tie_lo10(_glapi_tls_Dispatch), %g1'
+-        print '\tGL_LL\t[%g2 + %g1], %g2, GL_TIE_LD(_glapi_tls_Dispatch)'
+-        print '\tGL_LL\t[%g7+%g2], %g1'
+-        print '\tGL_LL\t[%g1 + %g3], %g1'
+-        print '\tjmp\t%g1'
+-        print '\t nop'
+-        print '\t.size\t__glapi_sparc_tls_stub, .-__glapi_sparc_tls_stub'
+-        print ''
+-        print '#define GL_STUB(fn, off)\t\t\t\t\\'
+-        print '\tGLOBL_FN(fn);\t\t\t\t\t\\'
+-        print 'fn:\tba\t__glapi_sparc_tls_stub;\t\t\t\\'
+-        print '\t sethi\tGL_OFF(off), %g3;\t\t\t\\'
+-        print '\t.size\tfn,.-fn;'
+-        print ''
+-        print '#elif defined(HAVE_PTHREAD)'
+-        print ''
+-        print '\t/* 64-bit 0x00 --> sethi %hh(_glapi_Dispatch), %g1 */'
+-        print '\t/* 64-bit 0x04 --> sethi %lm(_glapi_Dispatch), %g2 */'
+-        print '\t/* 64-bit 0x08 --> or %g1, %hm(_glapi_Dispatch), %g1 */'
+-        print '\t/* 64-bit 0x0c --> sllx %g1, 32, %g1 */'
+-        print '\t/* 64-bit 0x10 --> add %g1, %g2, %g1 */'
+-        print '\t/* 64-bit 0x14 --> ldx [%g1 + %lo(_glapi_Dispatch)], %g1 */'
+-        print ''
+-        print '\t/* 32-bit 0x00 --> sethi %hi(_glapi_Dispatch), %g1 */'
+-        print '\t/* 32-bit 0x04 --> ld [%g1 + %lo(_glapi_Dispatch)], %g1 */'
+-        print ''
+-        print '\t.data'
+-        print '\t.align\t32'
+-        print ''
+-        print '\tGLOBL_FN(__glapi_sparc_pthread_stub)'
+-        print '\tHIDDEN(__glapi_sparc_pthread_stub)'
+-        print '__glapi_sparc_pthread_stub: /* Call offset in %g3 */'
+-        print '\tmov\t%o7, %g1'
+-        print '\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2'
+-        print '\tcall\t__glapi_sparc_get_pc'
+-        print '\t add\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2'
+-        print '\tmov\t%g1, %o7'
+-        print '\tsethi\t%hi(_glapi_Dispatch), %g1'
+-        print '\tor\t%g1, %lo(_glapi_Dispatch), %g1'
+-        print '\tsrl\t%g3, 10, %g3'
+-        print '\tGL_LL\t[%g2+%g1], %g2'
+-        print '\tGL_LL\t[%g2], %g1'
+-        print '\tcmp\t%g1, 0'
+-        print '\tbe\t2f'
+-        print '\t nop'
+-        print '1:\tGL_LL\t[%g1 + %g3], %g1'
+-        print '\tjmp\t%g1'
+-        print '\t nop'
+-        print '2:\tsave\t%sp, GL_STACK_SIZE, %sp'
+-        print '\tmov\t%g3, %l0'
+-        print '\tcall\t_glapi_get_dispatch'
+-        print '\t nop'
+-        print '\tmov\t%o0, %g1'
+-        print '\tmov\t%l0, %g3'
+-        print '\tba\t1b'
+-        print '\t restore %g0, %g0, %g0'
+-        print '\t.size\t__glapi_sparc_pthread_stub, .-__glapi_sparc_pthread_stub'
+-        print ''
+-        print '#define GL_STUB(fn, off)\t\t\t\\'
+-        print '\tGLOBL_FN(fn);\t\t\t\t\\'
+-        print 'fn:\tba\t__glapi_sparc_pthread_stub;\t\\'
+-        print '\t sethi\tGL_OFF(off), %g3;\t\t\\'
+-        print '\t.size\tfn,.-fn;'
+-        print ''
+-        print '#else /* Non-threaded version. */'
+-        print ''
+-        print '\t.type	__glapi_sparc_nothread_stub, @function'
+-        print '__glapi_sparc_nothread_stub: /* Call offset in %g3 */'
+-        print '\tmov\t%o7, %g1'
+-        print '\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2'
+-        print '\tcall\t__glapi_sparc_get_pc'
+-        print '\t add\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2'
+-        print '\tmov\t%g1, %o7'
+-        print '\tsrl\t%g3, 10, %g3'
+-        print '\tsethi\t%hi(_glapi_Dispatch), %g1'
+-        print '\tor\t%g1, %lo(_glapi_Dispatch), %g1'
+-        print '\tGL_LL\t[%g2+%g1], %g2'
+-        print '\tGL_LL\t[%g2], %g1'
+-        print '\tGL_LL\t[%g1 + %g3], %g1'
+-        print '\tjmp\t%g1'
+-        print '\t nop'
+-        print '\t.size\t__glapi_sparc_nothread_stub, .-__glapi_sparc_nothread_stub'
+-        print ''
+-        print '#define GL_STUB(fn, off)\t\t\t\\'
+-        print '\tGLOBL_FN(fn);\t\t\t\t\\'
+-        print 'fn:\tba\t__glapi_sparc_nothread_stub;\t\\'
+-        print '\t sethi\tGL_OFF(off), %g3;\t\t\\'
+-        print '\t.size\tfn,.-fn;'
+-        print ''
+-        print '#endif'
+-        print ''
+-        print '#define GL_STUB_ALIAS(fn, alias)		\\'
+-        print '	.globl	fn;				\\'
+-        print '	.set	fn, alias'
+-        print ''
+-        print '\t.text'
+-        print '\t.align\t32'
+-        print ''
+-        print '\t.globl\tgl_dispatch_functions_start'
+-        print '\tHIDDEN(gl_dispatch_functions_start)'
+-        print 'gl_dispatch_functions_start:'
+-        print ''
++        print('#ifdef __arch64__')
++        print('#define GL_OFF(N)\t((N) * 8)')
++        print('#define GL_LL\t\tldx')
++        print('#define GL_TIE_LD(SYM)\t%tie_ldx(SYM)')
++        print('#define GL_STACK_SIZE\t128')
++        print('#else')
++        print('#define GL_OFF(N)\t((N) * 4)')
++        print('#define GL_LL\t\tld')
++        print('#define GL_TIE_LD(SYM)\t%tie_ld(SYM)')
++        print('#define GL_STACK_SIZE\t64')
++        print('#endif')
++        print('')
++        print('#define GLOBL_FN(x) .globl x ; .type x, @function')
++        print('#define HIDDEN(x) .hidden x')
++        print('')
++        print('\t.register %g2, #scratch')
++        print('\t.register %g3, #scratch')
++        print('')
++        print('\t.text')
++        print('')
++        print('\tGLOBL_FN(__glapi_sparc_icache_flush)')
++        print('\tHIDDEN(__glapi_sparc_icache_flush)')
++        print('\t.type\t__glapi_sparc_icache_flush, @function')
++        print('__glapi_sparc_icache_flush: /* %o0 = insn_addr */')
++        print('\tflush\t%o0')
++        print('\tretl')
++        print('\t nop')
++        print('')
++        print('\t.align\t32')
++        print('')
++        print('\t.type\t__glapi_sparc_get_pc, @function')
++        print('__glapi_sparc_get_pc:')
++        print('\tretl')
++        print('\t add\t%o7, %g2, %g2')
++        print('\t.size\t__glapi_sparc_get_pc, .-__glapi_sparc_get_pc')
++        print('')
++        print('#ifdef GLX_USE_TLS')
++        print('')
++        print('\tGLOBL_FN(__glapi_sparc_get_dispatch)')
++        print('\tHIDDEN(__glapi_sparc_get_dispatch)')
++        print('__glapi_sparc_get_dispatch:')
++        print('\tmov\t%o7, %g1')
++        print('\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2')
++        print('\tcall\t__glapi_sparc_get_pc')
++        print('\tadd\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2')
++        print('\tmov\t%g1, %o7')
++        print('\tsethi\t%tie_hi22(_glapi_tls_Dispatch), %g1')
++        print('\tadd\t%g1, %tie_lo10(_glapi_tls_Dispatch), %g1')
++        print('\tGL_LL\t[%g2 + %g1], %g2, GL_TIE_LD(_glapi_tls_Dispatch)')
++        print('\tretl')
++        print('\t mov\t%g2, %o0')
++        print('')
++        print('\t.data')
++        print('\t.align\t32')
++        print('')
++        print('\t/* --> sethi %hi(_glapi_tls_Dispatch), %g1 */')
++        print('\t/* --> or %g1, %lo(_glapi_tls_Dispatch), %g1 */')
++        print('\tGLOBL_FN(__glapi_sparc_tls_stub)')
++        print('\tHIDDEN(__glapi_sparc_tls_stub)')
++        print('__glapi_sparc_tls_stub: /* Call offset in %g3 */')
++        print('\tmov\t%o7, %g1')
++        print('\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2')
++        print('\tcall\t__glapi_sparc_get_pc')
++        print('\tadd\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2')
++        print('\tmov\t%g1, %o7')
++        print('\tsrl\t%g3, 10, %g3')
++        print('\tsethi\t%tie_hi22(_glapi_tls_Dispatch), %g1')
++        print('\tadd\t%g1, %tie_lo10(_glapi_tls_Dispatch), %g1')
++        print('\tGL_LL\t[%g2 + %g1], %g2, GL_TIE_LD(_glapi_tls_Dispatch)')
++        print('\tGL_LL\t[%g7+%g2], %g1')
++        print('\tGL_LL\t[%g1 + %g3], %g1')
++        print('\tjmp\t%g1')
++        print('\t nop')
++        print('\t.size\t__glapi_sparc_tls_stub, .-__glapi_sparc_tls_stub')
++        print('')
++        print('#define GL_STUB(fn, off)\t\t\t\t\\')
++        print('\tGLOBL_FN(fn);\t\t\t\t\t\\')
++        print('fn:\tba\t__glapi_sparc_tls_stub;\t\t\t\\')
++        print('\t sethi\tGL_OFF(off), %g3;\t\t\t\\')
++        print('\t.size\tfn,.-fn;')
++        print('')
++        print('#elif defined(HAVE_PTHREAD)')
++        print('')
++        print('\t/* 64-bit 0x00 --> sethi %hh(_glapi_Dispatch), %g1 */')
++        print('\t/* 64-bit 0x04 --> sethi %lm(_glapi_Dispatch), %g2 */')
++        print('\t/* 64-bit 0x08 --> or %g1, %hm(_glapi_Dispatch), %g1 */')
++        print('\t/* 64-bit 0x0c --> sllx %g1, 32, %g1 */')
++        print('\t/* 64-bit 0x10 --> add %g1, %g2, %g1 */')
++        print('\t/* 64-bit 0x14 --> ldx [%g1 + %lo(_glapi_Dispatch)], %g1 */')
++        print('')
++        print('\t/* 32-bit 0x00 --> sethi %hi(_glapi_Dispatch), %g1 */')
++        print('\t/* 32-bit 0x04 --> ld [%g1 + %lo(_glapi_Dispatch)], %g1 */')
++        print('')
++        print('\t.data')
++        print('\t.align\t32')
++        print('')
++        print('\tGLOBL_FN(__glapi_sparc_pthread_stub)')
++        print('\tHIDDEN(__glapi_sparc_pthread_stub)')
++        print('__glapi_sparc_pthread_stub: /* Call offset in %g3 */')
++        print('\tmov\t%o7, %g1')
++        print('\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2')
++        print('\tcall\t__glapi_sparc_get_pc')
++        print('\t add\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2')
++        print('\tmov\t%g1, %o7')
++        print('\tsethi\t%hi(_glapi_Dispatch), %g1')
++        print('\tor\t%g1, %lo(_glapi_Dispatch), %g1')
++        print('\tsrl\t%g3, 10, %g3')
++        print('\tGL_LL\t[%g2+%g1], %g2')
++        print('\tGL_LL\t[%g2], %g1')
++        print('\tcmp\t%g1, 0')
++        print('\tbe\t2f')
++        print('\t nop')
++        print('1:\tGL_LL\t[%g1 + %g3], %g1')
++        print('\tjmp\t%g1')
++        print('\t nop')
++        print('2:\tsave\t%sp, GL_STACK_SIZE, %sp')
++        print('\tmov\t%g3, %l0')
++        print('\tcall\t_glapi_get_dispatch')
++        print('\t nop')
++        print('\tmov\t%o0, %g1')
++        print('\tmov\t%l0, %g3')
++        print('\tba\t1b')
++        print('\t restore %g0, %g0, %g0')
++        print('\t.size\t__glapi_sparc_pthread_stub, .-__glapi_sparc_pthread_stub')
++        print('')
++        print('#define GL_STUB(fn, off)\t\t\t\\')
++        print('\tGLOBL_FN(fn);\t\t\t\t\\')
++        print('fn:\tba\t__glapi_sparc_pthread_stub;\t\\')
++        print('\t sethi\tGL_OFF(off), %g3;\t\t\\')
++        print('\t.size\tfn,.-fn;')
++        print('')
++        print('#else /* Non-threaded version. */')
++        print('')
++        print('\t.type	__glapi_sparc_nothread_stub, @function')
++        print('__glapi_sparc_nothread_stub: /* Call offset in %g3 */')
++        print('\tmov\t%o7, %g1')
++        print('\tsethi\t%hi(_GLOBAL_OFFSET_TABLE_-4), %g2')
++        print('\tcall\t__glapi_sparc_get_pc')
++        print('\t add\t%g2, %lo(_GLOBAL_OFFSET_TABLE_+4), %g2')
++        print('\tmov\t%g1, %o7')
++        print('\tsrl\t%g3, 10, %g3')
++        print('\tsethi\t%hi(_glapi_Dispatch), %g1')
++        print('\tor\t%g1, %lo(_glapi_Dispatch), %g1')
++        print('\tGL_LL\t[%g2+%g1], %g2')
++        print('\tGL_LL\t[%g2], %g1')
++        print('\tGL_LL\t[%g1 + %g3], %g1')
++        print('\tjmp\t%g1')
++        print('\t nop')
++        print('\t.size\t__glapi_sparc_nothread_stub, .-__glapi_sparc_nothread_stub')
++        print('')
++        print('#define GL_STUB(fn, off)\t\t\t\\')
++        print('\tGLOBL_FN(fn);\t\t\t\t\\')
++        print('fn:\tba\t__glapi_sparc_nothread_stub;\t\\')
++        print('\t sethi\tGL_OFF(off), %g3;\t\t\\')
++        print('\t.size\tfn,.-fn;')
++        print('')
++        print('#endif')
++        print('')
++        print('#define GL_STUB_ALIAS(fn, alias)		\\')
++        print('	.globl	fn;				\\')
++        print('	.set	fn, alias')
++        print('')
++        print('\t.text')
++        print('\t.align\t32')
++        print('')
++        print('\t.globl\tgl_dispatch_functions_start')
++        print('\tHIDDEN(gl_dispatch_functions_start)')
++        print('gl_dispatch_functions_start:')
++        print('')
+         return
+ 
+     def printRealFooter(self):
+-        print ''
+-        print '\t.globl\tgl_dispatch_functions_end'
+-        print '\tHIDDEN(gl_dispatch_functions_end)'
+-        print 'gl_dispatch_functions_end:'
++        print('')
++        print('\t.globl\tgl_dispatch_functions_end')
++        print('\tHIDDEN(gl_dispatch_functions_end)')
++        print('gl_dispatch_functions_end:')
+         return
+ 
+     def printBody(self, api):
+         for f in api.functionIterateByOffset():
+             name = f.dispatch_name()
+ 
+-            print '\tGL_STUB(gl%s, %d)' % (name, f.offset)
++            print('\tGL_STUB(gl%s, %d)' % (name, f.offset))
+ 
+             if not f.is_static_entry_point(f.name):
+-                print '\tHIDDEN(gl%s)' % (name)
++                print('\tHIDDEN(gl%s)' % (name))
+ 
+         for f in api.functionIterateByOffset():
+             name = f.dispatch_name()
+@@ -235,11 +235,11 @@
+                         text = '\tGL_STUB_ALIAS(gl%s, gl%s)' % (n, f.name)
+ 
+                         if f.has_different_protocol(n):
+-                            print '#ifndef GLX_INDIRECT_RENDERING'
+-                            print text
+-                            print '#endif'
++                            print('#ifndef GLX_INDIRECT_RENDERING')
++                            print(text)
++                            print('#endif')
+                         else:
+-                            print text
++                            print(text)
+ 
+         return
+ 
+--- ./src/mapi/glapi/gen/gl_XML.py	(original)
++++ ./src/mapi/glapi/gen/gl_XML.py	(refactored)
+@@ -125,17 +125,17 @@
+     def printHeader(self):
+         """Print the header associated with all files and call the printRealHeader method."""
+ 
+-        print '/* DO NOT EDIT - This file generated automatically by %s script */' \
+-                % (self.name)
+-        print ''
+-        print '/*'
+-        print (' * ' + self.license.replace('\n', '\n * ')).replace(' \n', '\n')
+-        print ' */'
+-        print ''
++        print('/* DO NOT EDIT - This file generated automatically by %s script */' \
++                % (self.name))
++        print('')
++        print('/*')
++        print((' * ' + self.license.replace('\n', '\n * ')).replace(' \n', '\n'))
++        print(' */')
++        print('')
+         if self.header_tag:
+-            print '#if !defined( %s )' % (self.header_tag)
+-            print '#  define %s' % (self.header_tag)
+-            print ''
++            print('#if !defined( %s )' % (self.header_tag))
++            print('#  define %s' % (self.header_tag))
++            print('')
+         self.printRealHeader();
+         return
+ 
+@@ -146,13 +146,13 @@
+         self.printRealFooter()
+ 
+         if self.undef_list:
+-            print ''
++            print('')
+             for u in self.undef_list:
+-                print "#  undef %s" % (u)
++                print("#  undef %s" % (u))
+ 
+         if self.header_tag:
+-            print ''
+-            print '#endif /* !defined( %s ) */' % (self.header_tag)
++            print('')
++            print('#endif /* !defined( %s ) */' % (self.header_tag))
+ 
+ 
+     def printRealHeader(self):
+@@ -182,11 +182,11 @@
+         The name is also added to the file's undef_list.
+         """
+         self.undef_list.append("PURE")
+-        print """#  if defined(__GNUC__) || (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590))
++        print("""#  if defined(__GNUC__) || (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590))
+ #    define PURE __attribute__((pure))
+ #  else
+ #    define PURE
+-#  endif"""
++#  endif""")
+         return
+ 
+ 
+@@ -202,11 +202,11 @@
+         """
+ 
+         self.undef_list.append("FASTCALL")
+-        print """#  if defined(__i386__) && defined(__GNUC__) && !defined(__CYGWIN__) && !defined(__MINGW32__)
++        print("""#  if defined(__i386__) && defined(__GNUC__) && !defined(__CYGWIN__) && !defined(__MINGW32__)
+ #    define FASTCALL __attribute__((fastcall))
+ #  else
+ #    define FASTCALL
+-#  endif"""
++#  endif""")
+         return
+ 
+ 
+@@ -222,11 +222,11 @@
+         """
+ 
+         self.undef_list.append(S)
+-        print """#  if defined(__GNUC__) && !defined(__CYGWIN__) && !defined(__MINGW32__)
++        print("""#  if defined(__GNUC__) && !defined(__CYGWIN__) && !defined(__MINGW32__)
+ #    define %s  __attribute__((visibility("%s")))
+ #  else
+ #    define %s
+-#  endif""" % (S, s, S)
++#  endif""" % (S, s, S))
+         return
+ 
+ 
+@@ -242,11 +242,11 @@
+         """
+ 
+         self.undef_list.append("NOINLINE")
+-        print """#  if defined(__GNUC__)
++        print("""#  if defined(__GNUC__)
+ #    define NOINLINE __attribute__((noinline))
+ #  else
+ #    define NOINLINE
+-#  endif"""
++#  endif""")
+         return
+ 
+ 
+@@ -281,7 +281,7 @@
+ 
+     try:
+         core_version = float(name)
+-    except Exception,e:
++    except Exception as e:
+         core_version = 0.0
+ 
+     if core_version > 0.0:
+@@ -362,7 +362,7 @@
+         else:
+             try:
+                 c = int(temp)
+-            except Exception,e:
++            except Exception as e:
+                 raise RuntimeError('Invalid count value "%s" for enum "%s" in function "%s" when an integer was expected.' % (temp, self.name, n))
+ 
+             self.default_count = c
+@@ -423,7 +423,7 @@
+             count = int(c)
+             self.count = count
+             self.counter = None
+-        except Exception,e:
++        except Exception as e:
+             count = 1
+             self.count = 0
+             self.counter = c
+@@ -825,7 +825,7 @@
+         versions.
+         """
+         result = []
+-        for entry_point, api_to_ver in self.entry_point_api_map.iteritems():
++        for entry_point, api_to_ver in self.entry_point_api_map.items():
+             if api not in api_to_ver:
+                 continue
+             if version is not None and version < api_to_ver[api]:
+@@ -872,7 +872,7 @@
+     def filter_functions(self, entry_point_list):
+         """Filter out entry points not in entry_point_list."""
+         functions_by_name = {}
+-        for func in self.functions_by_name.itervalues():
++        for func in self.functions_by_name.values():
+             entry_points = [ent for ent in func.entry_points if ent in entry_point_list]
+             if entry_points:
+                 func.filter_entry_points(entry_points)
+@@ -885,7 +885,7 @@
+         optionally, not in the given version of the given API).
+         """
+         functions_by_name = {}
+-        for func in self.functions_by_name.itervalues():
++        for func in self.functions_by_name.values():
+             entry_points = func.entry_points_for_api_version(api, version)
+             if entry_points:
+                 func.filter_entry_points(entry_points)
+@@ -934,7 +934,7 @@
+                 temp_name = child.get( "name" )
+                 self.category_dict[ temp_name ] = [cat_name, cat_number]
+ 
+-                if self.functions_by_name.has_key( func_name ):
++                if func_name in self.functions_by_name:
+                     func = self.functions_by_name[ func_name ]
+                     func.process_element( child )
+                 else:
+@@ -971,7 +971,7 @@
+             if (cat == None) or (cat == cat_name):
+                 [func_cat_type, key] = classify_category(cat_name, cat_number)
+ 
+-                if not lists[func_cat_type].has_key(key):
++                if key not in lists[func_cat_type]:
+                     lists[func_cat_type][key] = {}
+ 
+                 lists[func_cat_type][key][func.name] = func
+@@ -979,11 +979,11 @@
+ 
+         functions = []
+         for func_cat_type in range(0,4):
+-            keys = lists[func_cat_type].keys()
++            keys = list(lists[func_cat_type].keys())
+             keys.sort()
+ 
+             for key in keys:
+-                names = lists[func_cat_type][key].keys()
++                names = list(lists[func_cat_type][key].keys())
+                 names.sort()
+ 
+                 for name in names:
+@@ -994,13 +994,13 @@
+ 
+     def functionIterateByOffset(self):
+         max_offset = -1
+-        for func in self.functions_by_name.itervalues():
++        for func in self.functions_by_name.values():
+             if func.offset > max_offset:
+                 max_offset = func.offset
+ 
+ 
+         temp = [None for i in range(0, max_offset + 1)]
+-        for func in self.functions_by_name.itervalues():
++        for func in self.functions_by_name.values():
+             if func.offset != -1:
+                 temp[ func.offset ] = func
+ 
+@@ -1014,11 +1014,11 @@
+ 
+ 
+     def functionIterateAll(self):
+-        return self.functions_by_name.itervalues()
++        return iter(self.functions_by_name.values())
+ 
+ 
+     def enumIterateByName(self):
+-        keys = self.enums_by_name.keys()
++        keys = list(self.enums_by_name.keys())
+         keys.sort()
+ 
+         list = []
+@@ -1038,7 +1038,7 @@
+ 
+         list = []
+         for cat_type in range(0,4):
+-            keys = self.categories[cat_type].keys()
++            keys = list(self.categories[cat_type].keys())
+             keys.sort()
+ 
+             for key in keys:
+@@ -1048,19 +1048,19 @@
+ 
+ 
+     def get_category_for_name( self, name ):
+-        if self.category_dict.has_key(name):
++        if name in self.category_dict:
+             return self.category_dict[name]
+         else:
+             return ["<unknown category>", None]
+ 
+ 
+     def typeIterate(self):
+-        return self.types_by_name.itervalues()
++        return iter(self.types_by_name.values())
+ 
+ 
+     def find_type( self, type_name ):
+         if type_name in self.types_by_name:
+             return self.types_by_name[ type_name ].type_expr
+         else:
+-            print "Unable to find base type matching \"%s\"." % (type_name)
++            print("Unable to find base type matching \"%s\"." % (type_name))
+             return None
+--- ./src/mapi/glapi/gen/gl_apitemp.py	(original)
++++ ./src/mapi/glapi/gen/gl_apitemp.py	(refactored)
+@@ -97,27 +97,27 @@
+             if (cat.startswith("es") or cat.startswith("GL_OES")):
+                 need_proto = True
+         if need_proto:
+-            print '%s %s KEYWORD2 NAME(%s)(%s);' % (keyword, f.return_type, n, f.get_parameter_string(name))
+-            print ''
+-
+-        print '%s %s KEYWORD2 NAME(%s)(%s)' % (keyword, f.return_type, n, f.get_parameter_string(name))
+-        print '{'
++            print('%s %s KEYWORD2 NAME(%s)(%s);' % (keyword, f.return_type, n, f.get_parameter_string(name)))
++            print('')
++
++        print('%s %s KEYWORD2 NAME(%s)(%s)' % (keyword, f.return_type, n, f.get_parameter_string(name)))
++        print('{')
+         if silence:
+-            print '    %s' % (silence)
++            print('    %s' % (silence))
+         if p_string == "":
+-            print '   %s(%s, (), (F, "gl%s();\\n"));' \
+-                    % (dispatch, f.name, name)
++            print('   %s(%s, (), (F, "gl%s();\\n"));' \
++                    % (dispatch, f.name, name))
+         else:
+-            print '   %s(%s, (%s), (F, "gl%s(%s);\\n", %s));' \
+-                    % (dispatch, f.name, p_string, name, t_string, o_string)
+-        print '}'
+-        print ''
++            print('   %s(%s, (%s), (F, "gl%s(%s);\\n", %s));' \
++                    % (dispatch, f.name, p_string, name, t_string, o_string))
++        print('}')
++        print('')
+         return
+ 
+     def printRealHeader(self):
+-        print ''
++        print('')
+         self.printVisibility( "HIDDEN", "hidden" )
+-        print """
++        print("""
+ /*
+  * This file is a template which generates the OpenGL API entry point
+  * functions.  It should be included by a .c file which first defines
+@@ -164,13 +164,13 @@
+ #error RETURN_DISPATCH must be defined
+ #endif
+ 
+-"""
++""")
+         return
+ 
+ 
+ 
+     def printInitDispatch(self, api):
+-        print """
++        print("""
+ #endif /* defined( NAME ) */
+ 
+ /*
+@@ -187,31 +187,31 @@
+ #error _GLAPI_SKIP_NORMAL_ENTRY_POINTS must not be defined
+ #endif
+ 
+-_glapi_proc DISPATCH_TABLE_NAME[] = {"""
++_glapi_proc DISPATCH_TABLE_NAME[] = {""")
+         for f in api.functionIterateByOffset():
+-            print '   TABLE_ENTRY(%s),' % (f.dispatch_name())
+-
+-        print '   /* A whole bunch of no-op functions.  These might be called'
+-        print '    * when someone tries to call a dynamically-registered'
+-        print '    * extension function without a current rendering context.'
+-        print '    */'
++            print('   TABLE_ENTRY(%s),' % (f.dispatch_name()))
++
++        print('   /* A whole bunch of no-op functions.  These might be called')
++        print('    * when someone tries to call a dynamically-registered')
++        print('    * extension function without a current rendering context.')
++        print('    */')
+         for i in range(1, 100):
+-            print '   TABLE_ENTRY(Unused),'
+-
+-        print '};'
+-        print '#endif /* DISPATCH_TABLE_NAME */'
+-        print ''
++            print('   TABLE_ENTRY(Unused),')
++
++        print('};')
++        print('#endif /* DISPATCH_TABLE_NAME */')
++        print('')
+         return
+ 
+ 
+     def printAliasedTable(self, api):
+-        print """
++        print("""
+ /*
+  * This is just used to silence compiler warnings.
+  * We list the functions which are not otherwise used.
+  */
+ #ifdef UNUSED_TABLE_NAME
+-_glapi_proc UNUSED_TABLE_NAME[] = {"""
++_glapi_proc UNUSED_TABLE_NAME[] = {""")
+ 
+         normal_entries = []
+         proto_entries = []
+@@ -230,18 +230,18 @@
+             normal_entries.extend(normal_ents)
+             proto_entries.extend(proto_ents)
+ 
+-        print '#ifndef _GLAPI_SKIP_NORMAL_ENTRY_POINTS'
++        print('#ifndef _GLAPI_SKIP_NORMAL_ENTRY_POINTS')
+         for ent in normal_entries:
+-            print '   TABLE_ENTRY(%s),' % (ent)
+-        print '#endif /* _GLAPI_SKIP_NORMAL_ENTRY_POINTS */'
+-        print '#ifndef _GLAPI_SKIP_PROTO_ENTRY_POINTS'
++            print('   TABLE_ENTRY(%s),' % (ent))
++        print('#endif /* _GLAPI_SKIP_NORMAL_ENTRY_POINTS */')
++        print('#ifndef _GLAPI_SKIP_PROTO_ENTRY_POINTS')
+         for ent in proto_entries:
+-            print '   TABLE_ENTRY(%s),' % (ent)
+-        print '#endif /* _GLAPI_SKIP_PROTO_ENTRY_POINTS */'
+-
+-        print '};'
+-        print '#endif /*UNUSED_TABLE_NAME*/'
+-        print ''
++            print('   TABLE_ENTRY(%s),' % (ent))
++        print('#endif /* _GLAPI_SKIP_PROTO_ENTRY_POINTS */')
++
++        print('};')
++        print('#endif /*UNUSED_TABLE_NAME*/')
++        print('')
+         return
+ 
+ 
+@@ -278,23 +278,23 @@
+             normal_entry_points.append((func, normal_ents))
+             proto_entry_points.append((func, proto_ents))
+ 
+-        print '#ifndef _GLAPI_SKIP_NORMAL_ENTRY_POINTS'
+-        print ''
++        print('#ifndef _GLAPI_SKIP_NORMAL_ENTRY_POINTS')
++        print('')
+         for func, ents in normal_entry_points:
+             for ent in ents:
+                 self.printFunction(func, ent)
+-        print ''
+-        print '#endif /* _GLAPI_SKIP_NORMAL_ENTRY_POINTS */'
+-        print ''
+-        print '/* these entry points might require different protocols */'
+-        print '#ifndef _GLAPI_SKIP_PROTO_ENTRY_POINTS'
+-        print ''
++        print('')
++        print('#endif /* _GLAPI_SKIP_NORMAL_ENTRY_POINTS */')
++        print('')
++        print('/* these entry points might require different protocols */')
++        print('#ifndef _GLAPI_SKIP_PROTO_ENTRY_POINTS')
++        print('')
+         for func, ents in proto_entry_points:
+             for ent in ents:
+                 self.printFunction(func, ent)
+-        print ''
+-        print '#endif /* _GLAPI_SKIP_PROTO_ENTRY_POINTS */'
+-        print ''
++        print('')
++        print('#endif /* _GLAPI_SKIP_PROTO_ENTRY_POINTS */')
++        print('')
+ 
+         self.printInitDispatch(api)
+         self.printAliasedTable(api)
+--- ./src/mapi/glapi/gen/gl_enums.py	(original)
++++ ./src/mapi/glapi/gen/gl_enums.py	(refactored)
+@@ -48,20 +48,20 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include "main/glheader.h"'
+-        print '#include "main/enums.h"'
+-        print '#include "main/imports.h"'
+-        print '#include "main/mtypes.h"'
+-        print ''
+-        print 'typedef struct PACKED {'
+-        print '   uint32_t offset;'
+-        print '   int n;'
+-        print '} enum_elt;'
+-        print ''
++        print('#include "main/glheader.h"')
++        print('#include "main/enums.h"')
++        print('#include "main/imports.h"')
++        print('#include "main/mtypes.h"')
++        print('')
++        print('typedef struct PACKED {')
++        print('   uint32_t offset;')
++        print('   int n;')
++        print('} enum_elt;')
++        print('')
+         return
+ 
+     def print_code(self):
+-        print """
++        print("""
+ typedef int (*cfunc)(const void *, const void *);
+ 
+ /**
+@@ -144,7 +144,7 @@
+ }
+ 
+ 
+-"""
++""")
+         return
+ 
+ 
+@@ -154,37 +154,37 @@
+         sorted_enum_values = sorted(self.enum_table.keys())
+         string_offsets = {}
+         i = 0;
+-        print '#if defined(__GNUC__)'
+-        print '# define LONGSTRING __extension__'
+-        print '#else'
+-        print '# define LONGSTRING'
+-        print '#endif'
+-        print ''
+-        print 'LONGSTRING static const char enum_string_table[] = {'
++        print('#if defined(__GNUC__)')
++        print('# define LONGSTRING __extension__')
++        print('#else')
++        print('# define LONGSTRING')
++        print('#endif')
++        print('')
++        print('LONGSTRING static const char enum_string_table[] = {')
+         # We express the very long concatenation of enum strings as an array
+         # of characters rather than as a string literal to work-around MSVC's
+         # 65535 character limit.
+         for enum in sorted_enum_values:
+             (name, pri) = self.enum_table[enum]
+-            print "  ",
++            print("  ", end=' ')
+             for ch in name:
+-                print "'%c'," % ch,
+-            print "'\\0',"
++                print("'%c'," % ch, end=' ')
++            print("'\\0',")
+ 
+             string_offsets[ enum ] = i
+             i += len(name) + 1
+ 
+-        print '};'
+-        print ''
+-
+-
+-        print 'static const enum_elt enum_string_table_offsets[%u] =' % (len(self.enum_table))
+-        print '{'
++        print('};')
++        print('')
++
++
++        print('static const enum_elt enum_string_table_offsets[%u] =' % (len(self.enum_table)))
++        print('{')
+         for enum in sorted_enum_values:
+             (name, pri) = self.enum_table[enum]
+-            print '   { %5u, 0x%08X }, /* %s */' % (string_offsets[enum], enum, name)
+-        print '};'
+-        print ''
++            print('   { %5u, 0x%08X }, /* %s */' % (string_offsets[enum], enum, name))
++        print('};')
++        print('')
+ 
+         self.print_code()
+         return
+@@ -240,7 +240,7 @@
+             # confuse us.  GL_ACTIVE_PROGRAM_EXT is OK to lose because
+             # we choose GL_ACTIVE PROGRAM instead.
+             if name in self.string_to_int and name != "GL_ACTIVE_PROGRAM_EXT":
+-                print "#error Renumbering {0} from {1} to {2}".format(name, self.string_to_int[name], value)
++                print("#error Renumbering {0} from {1} to {2}".format(name, self.string_to_int[name], value))
+ 
+             self.string_to_int[name] = value
+ 
+--- ./src/mapi/glapi/gen/gl_genexec.py	(original)
++++ ./src/mapi/glapi/gen/gl_genexec.py	(refactored)
+@@ -166,10 +166,10 @@
+             'Intel Corporation')
+ 
+     def printRealHeader(self):
+-        print header
++        print(header)
+ 
+     def printRealFooter(self):
+-        print footer
++        print(footer)
+ 
+     def printBody(self, api):
+         # Collect SET_* calls by the condition under which they should
+@@ -237,10 +237,10 @@
+         # Print out an if statement for each unique condition, with
+         # the SET_* calls nested inside it.
+         for condition in sorted(settings_by_condition.keys()):
+-            print '   if ({0}) {{'.format(condition)
++            print('   if ({0}) {{'.format(condition))
+             for setting in sorted(settings_by_condition[condition]):
+-                print '      {0}'.format(setting)
+-            print '   }'
++                print('      {0}'.format(setting))
++            print('   }')
+ 
+ 
+ def _parser():
+--- ./src/mapi/glapi/gen/gl_gentable.py	(original)
++++ ./src/mapi/glapi/gen/gl_gentable.py	(refactored)
+@@ -173,12 +173,12 @@
+ 
+ 
+     def printRealHeader(self):
+-        print header
++        print(header)
+         return
+ 
+ 
+     def printRealFooter(self):
+-        print footer
++        print(footer)
+         return
+ 
+ 
+@@ -186,13 +186,13 @@
+ 
+         # Determine how many functions have a defined offset.
+         func_count = 0
+-        for f in api.functions_by_name.itervalues():
++        for f in api.functions_by_name.values():
+             if f.offset != -1:
+                 func_count += 1
+ 
+         # Build the mapping from offset to function name.
+         funcnames = [None] * func_count
+-        for f in api.functions_by_name.itervalues():
++        for f in api.functions_by_name.values():
+             if f.offset != -1:
+                 if not (funcnames[f.offset] is None):
+                     raise Exception("Function table has more than one function with same offset (offset %d, func %s)" % (f.offset, f.name))
+@@ -200,15 +200,15 @@
+ 
+         # Check that the table has no gaps.  We expect a function at every offset,
+         # and the code which generates the table relies on this.
+-        for i in xrange(0, func_count):
++        for i in range(0, func_count):
+             if funcnames[i] is None:
+                 raise Exception("Function table has no function at offset %d" % (i))
+ 
+-        print "#define GLAPI_TABLE_COUNT %d" % func_count
+-        print "static const char * const _glapi_table_func_names[GLAPI_TABLE_COUNT] = {"
+-        for i in xrange(0, func_count):
+-            print "    /* %5d */ \"%s\"," % (i, funcnames[i])
+-        print "};"
++        print("#define GLAPI_TABLE_COUNT %d" % func_count)
++        print("static const char * const _glapi_table_func_names[GLAPI_TABLE_COUNT] = {")
++        for i in range(0, func_count):
++            print("    /* %5d */ \"%s\"," % (i, funcnames[i]))
++        print("};")
+ 
+         return
+ 
+--- ./src/mapi/glapi/gen/gl_marshal.py	(original)
++++ ./src/mapi/glapi/gen/gl_marshal.py	(refactored)
+@@ -43,9 +43,9 @@
+ 
+ def out(str):
+     if str:
+-        print ' '*current_indent + str
++        print(' '*current_indent + str)
+     else:
+-        print ''
++        print('')
+ 
+ 
+ @contextlib.contextmanager
+@@ -65,21 +65,21 @@
+             'Copyright (C) 2012 Intel Corporation', 'INTEL CORPORATION')
+ 
+     def printRealHeader(self):
+-        print header
+-        print '#ifdef HAVE_PTHREAD'
+-        print
+-        print 'static inline int safe_mul(int a, int b)'
+-        print '{'
+-        print '    if (a < 0 || b < 0) return -1;'
+-        print '    if (a == 0 || b == 0) return 0;'
+-        print '    if (a > INT_MAX / b) return -1;'
+-        print '    return a * b;'
+-        print '}'
+-        print
++        print(header)
++        print('#ifdef HAVE_PTHREAD')
++        print()
++        print('static inline int safe_mul(int a, int b)')
++        print('{')
++        print('    if (a < 0 || b < 0) return -1;')
++        print('    if (a == 0 || b == 0) return 0;')
++        print('    if (a > INT_MAX / b) return -1;')
++        print('    return a * b;')
++        print('}')
++        print()
+ 
+     def printRealFooter(self):
+-        print
+-        print '#endif'
++        print()
++        print('#endif')
+ 
+     def print_sync_call(self, func):
+         call = 'CALL_{0}(ctx->CurrentServerDispatch, ({1}))'.format(
+@@ -338,7 +338,7 @@
+ 
+ 
+ def show_usage():
+-    print 'Usage: %s [-f input_file_name]' % sys.argv[0]
++    print('Usage: %s [-f input_file_name]' % sys.argv[0])
+     sys.exit(1)
+ 
+ 
+@@ -347,7 +347,7 @@
+ 
+     try:
+         (args, trail) = getopt.getopt(sys.argv[1:], 'm:f:')
+-    except Exception,e:
++    except Exception as e:
+         show_usage()
+ 
+     for (arg,val) in args:
+--- ./src/mapi/glapi/gen/gl_marshal_h.py	(original)
++++ ./src/mapi/glapi/gen/gl_marshal_h.py	(refactored)
+@@ -47,24 +47,24 @@
+             'Copyright (C) 2012 Intel Corporation', 'INTEL CORPORATION')
+ 
+     def printRealHeader(self):
+-        print header
++        print(header)
+ 
+     def printRealFooter(self):
+-        print footer
++        print(footer)
+ 
+     def printBody(self, api):
+-        print 'enum marshal_dispatch_cmd_id'
+-        print '{'
++        print('enum marshal_dispatch_cmd_id')
++        print('{')
+         for func in api.functionIterateAll():
+             flavor = func.marshal_flavor()
+             if flavor in ('skip', 'sync'):
+                 continue
+-            print '   DISPATCH_CMD_{0},'.format(func.name)
+-        print '};'
++            print('   DISPATCH_CMD_{0},'.format(func.name))
++        print('};')
+ 
+ 
+ def show_usage():
+-    print 'Usage: %s [-f input_file_name]' % sys.argv[0]
++    print('Usage: %s [-f input_file_name]' % sys.argv[0])
+     sys.exit(1)
+ 
+ 
+@@ -73,7 +73,7 @@
+ 
+     try:
+         (args, trail) = getopt.getopt(sys.argv[1:], 'm:f:')
+-    except Exception,e:
++    except Exception as e:
+         show_usage()
+ 
+     for (arg,val) in args:
+--- ./src/mapi/glapi/gen/gl_procs.py	(original)
++++ ./src/mapi/glapi/gen/gl_procs.py	(refactored)
+@@ -42,7 +42,7 @@
+ (C) Copyright IBM Corporation 2004, 2006""", "BRIAN PAUL, IBM")
+ 
+     def printRealHeader(self):
+-        print """
++        print("""
+ /* This file is only included by glapi.c and is used for
+  * the GetProcAddress() function
+  */
+@@ -65,20 +65,20 @@
+ #  define NAME_FUNC_OFFSET(n,f1,f2,f3,o) { n , (_glapi_proc) f3 , o }
+ #endif
+ 
+-"""
++""")
+         return
+ 
+     def printRealFooter(self):
+-        print ''
+-        print '#undef NAME_FUNC_OFFSET'
++        print('')
++        print('#undef NAME_FUNC_OFFSET')
+         return
+ 
+     def printFunctionString(self, name):
+-        print '    "gl%s\\0"' % (name)
++        print('    "gl%s\\0"' % (name))
+ 
+     def printBody(self, api):
+-        print ''
+-        print 'static const char gl_string_table[] ='
++        print('')
++        print('static const char gl_string_table[] =')
+ 
+         base_offset = 0
+         table = []
+@@ -108,23 +108,23 @@
+                     base_offset += len(n) + 3
+ 
+ 
+-        print '    ;'
+-        print ''
+-        print ''
+-        print "#ifdef USE_MGL_NAMESPACE"
++        print('    ;')
++        print('')
++        print('')
++        print("#ifdef USE_MGL_NAMESPACE")
+         for func in api.functionIterateByOffset():
+             for n in func.entry_points:
+                 if (not func.is_static_entry_point(func.name)) or (func.has_different_protocol(n) and not func.is_static_entry_point(n)):
+-                    print '#define gl_dispatch_stub_%u mgl_dispatch_stub_%u' % (func.offset, func.offset)
++                    print('#define gl_dispatch_stub_%u mgl_dispatch_stub_%u' % (func.offset, func.offset))
+                     break
+-        print "#endif /* USE_MGL_NAMESPACE */"
+-        print ''
+-        print ''
+-        print '#if defined(NEED_FUNCTION_POINTER) || defined(GLX_INDIRECT_RENDERING)'
++        print("#endif /* USE_MGL_NAMESPACE */")
++        print('')
++        print('')
++        print('#if defined(NEED_FUNCTION_POINTER) || defined(GLX_INDIRECT_RENDERING)')
+         for func in api.functionIterateByOffset():
+             for n in func.entry_points:
+                 if (not func.is_static_entry_point(func.name)) or (func.has_different_protocol(n) and not func.is_static_entry_point(n)):
+-                    print '%s GLAPIENTRY gl_dispatch_stub_%u(%s);' % (func.return_type, func.offset, func.get_parameter_string())
++                    print('%s GLAPIENTRY gl_dispatch_stub_%u(%s);' % (func.return_type, func.offset, func.get_parameter_string()))
+                     break
+ 
+         if self.es:
+@@ -133,32 +133,32 @@
+                 for n in func.entry_points:
+                     cat, num = api.get_category_for_name(n)
+                     if (cat.startswith("es") or cat.startswith("GL_OES")):
+-                        if not categories.has_key(cat):
++                        if cat not in categories:
+                             categories[cat] = []
+                         proto = 'GLAPI %s GLAPIENTRY %s(%s);' \
+                                         % (func.return_type, "gl" + n, func.get_parameter_string(n))
+                         categories[cat].append(proto)
+             if categories:
+-                print ''
+-                print '/* OpenGL ES specific prototypes */'
+-                print ''
+-                keys = categories.keys()
++                print('')
++                print('/* OpenGL ES specific prototypes */')
++                print('')
++                keys = list(categories.keys())
+                 keys.sort()
+                 for key in keys:
+-                    print '/* category %s */' % key
+-                    print "\n".join(categories[key])
+-                print ''
++                    print('/* category %s */' % key)
++                    print("\n".join(categories[key]))
++                print('')
+ 
+-        print '#endif /* defined(NEED_FUNCTION_POINTER) || defined(GLX_INDIRECT_RENDERING) */'
++        print('#endif /* defined(NEED_FUNCTION_POINTER) || defined(GLX_INDIRECT_RENDERING) */')
+ 
+-        print ''
+-        print 'static const glprocs_table_t static_functions[] = {'
++        print('')
++        print('static const glprocs_table_t static_functions[] = {')
+ 
+         for info in table:
+-            print '    NAME_FUNC_OFFSET(%5u, %s, %s, %s, %d),' % info
++            print('    NAME_FUNC_OFFSET(%5u, %s, %s, %s, %d),' % info)
+ 
+-        print '    NAME_FUNC_OFFSET(-1, NULL, NULL, NULL, 0)'
+-        print '};'
++        print('    NAME_FUNC_OFFSET(-1, NULL, NULL, NULL, 0)')
++        print('};')
+         return
+ 
+ 
+--- ./src/mapi/glapi/gen/gl_table.py	(original)
++++ ./src/mapi/glapi/gen/gl_table.py	(refactored)
+@@ -46,30 +46,30 @@
+     def printBody(self, api):
+         for f in api.functionIterateByOffset():
+             if not f.is_abi() and not self.ifdef_emitted:
+-                print '#if !defined HAVE_SHARED_GLAPI'
++                print('#if !defined HAVE_SHARED_GLAPI')
+                 self.ifdef_emitted = True
+             arg_string = f.get_parameter_string()
+-            print '   %s (GLAPIENTRYP %s)(%s); /* %d */' % (
+-                f.return_type, f.name, arg_string, f.offset)
+-
+-        print '#endif /* !defined HAVE_SHARED_GLAPI */'
++            print('   %s (GLAPIENTRYP %s)(%s); /* %d */' % (
++                f.return_type, f.name, arg_string, f.offset))
++
++        print('#endif /* !defined HAVE_SHARED_GLAPI */')
+ 
+     def printRealHeader(self):
+-        print '#ifndef GLAPIENTRYP'
+-        print '# ifndef GLAPIENTRY'
+-        print '#  define GLAPIENTRY'
+-        print '# endif'
+-        print ''
+-        print '# define GLAPIENTRYP GLAPIENTRY *'
+-        print '#endif'
+-        print ''
+-        print ''
+-        print 'struct _glapi_table'
+-        print '{'
++        print('#ifndef GLAPIENTRYP')
++        print('# ifndef GLAPIENTRY')
++        print('#  define GLAPIENTRY')
++        print('# endif')
++        print('')
++        print('# define GLAPIENTRYP GLAPIENTRY *')
++        print('#endif')
++        print('')
++        print('')
++        print('struct _glapi_table')
++        print('{')
+         return
+ 
+     def printRealFooter(self):
+-        print '};'
++        print('};')
+         return
+ 
+ 
+@@ -85,7 +85,7 @@
+ 
+ 
+     def printRealHeader(self):
+-        print """
++        print("""
+ /**
+  * \\file main/dispatch.h
+  * Macros for handling GL dispatch tables.
+@@ -96,27 +96,27 @@
+  * can SET_FuncName, are used to get and set the dispatch pointer for the
+  * named function in the specified dispatch table.
+  */
+-"""
++""")
+         return
+ 
+ 
+     def printBody(self, api):
+-        print '#define CALL_by_offset(disp, cast, offset, parameters) \\'
+-        print '    (*(cast (GET_by_offset(disp, offset)))) parameters'
+-        print '#define GET_by_offset(disp, offset) \\'
+-        print '    (offset >= 0) ? (((_glapi_proc *)(disp))[offset]) : NULL'
+-        print '#define SET_by_offset(disp, offset, fn) \\'
+-        print '    do { \\'
+-        print '        if ( (offset) < 0 ) { \\'
+-        print '            /* fprintf( stderr, "[%s:%u] SET_by_offset(%p, %d, %s)!\\n", */ \\'
+-        print '            /*         __func__, __LINE__, disp, offset, # fn); */ \\'
+-        print '            /* abort(); */ \\'
+-        print '        } \\'
+-        print '        else { \\'
+-        print '            ( (_glapi_proc *) (disp) )[offset] = (_glapi_proc) fn; \\'
+-        print '        } \\'
+-        print '    } while(0)'
+-        print ''
++        print('#define CALL_by_offset(disp, cast, offset, parameters) \\')
++        print('    (*(cast (GET_by_offset(disp, offset)))) parameters')
++        print('#define GET_by_offset(disp, offset) \\')
++        print('    (offset >= 0) ? (((_glapi_proc *)(disp))[offset]) : NULL')
++        print('#define SET_by_offset(disp, offset, fn) \\')
++        print('    do { \\')
++        print('        if ( (offset) < 0 ) { \\')
++        print('            /* fprintf( stderr, "[%s:%u] SET_by_offset(%p, %d, %s)!\\n", */ \\')
++        print('            /*         __func__, __LINE__, disp, offset, # fn); */ \\')
++        print('            /* abort(); */ \\')
++        print('        } \\')
++        print('        else { \\')
++        print('            ( (_glapi_proc *) (disp) )[offset] = (_glapi_proc) fn; \\')
++        print('        } \\')
++        print('    } while(0)')
++        print('')
+ 
+         functions = []
+         abi_functions = []
+@@ -128,43 +128,43 @@
+             else:
+                 abi_functions.append([f, -1])
+ 
+-        print '/* total number of offsets below */'
+-        print '#define _gloffset_COUNT %d' % (len(abi_functions + functions))
+-        print ''
++        print('/* total number of offsets below */')
++        print('#define _gloffset_COUNT %d' % (len(abi_functions + functions)))
++        print('')
+ 
+         for f, index in abi_functions:
+-            print '#define _gloffset_%s %d' % (f.name, f.offset)
++            print('#define _gloffset_%s %d' % (f.name, f.offset))
+ 
+         remap_table = "driDispatchRemapTable"
+ 
+-        print '#define %s_size %u' % (remap_table, count)
+-        print 'extern int %s[ %s_size ];' % (remap_table, remap_table)
+-        print ''
++        print('#define %s_size %u' % (remap_table, count))
++        print('extern int %s[ %s_size ];' % (remap_table, remap_table))
++        print('')
+ 
+         for f, index in functions:
+-            print '#define %s_remap_index %u' % (f.name, index)
+-
+-        print ''
++            print('#define %s_remap_index %u' % (f.name, index))
++
++        print('')
+ 
+         for f, index in functions:
+-            print '#define _gloffset_%s %s[%s_remap_index]' % (f.name, remap_table, f.name)
+-
+-        print ''
++            print('#define _gloffset_%s %s[%s_remap_index]' % (f.name, remap_table, f.name))
++
++        print('')
+ 
+         for f, index in abi_functions + functions:
+             arg_string = gl_XML.create_parameter_string(f.parameters, 0)
+ 
+-            print 'typedef %s (GLAPIENTRYP _glptr_%s)(%s);' % (f.return_type, f.name, arg_string)
+-            print '#define CALL_%s(disp, parameters) \\' % (f.name)
+-            print '    (* GET_%s(disp)) parameters' % (f.name)
+-            print 'static inline _glptr_%s GET_%s(struct _glapi_table *disp) {' % (f.name, f.name)
+-            print '   return (_glptr_%s) (GET_by_offset(disp, _gloffset_%s));' % (f.name, f.name)
+-            print '}'
+-            print
+-            print 'static inline void SET_%s(struct _glapi_table *disp, %s (GLAPIENTRYP fn)(%s)) {' % (f.name, f.return_type, arg_string)
+-            print '   SET_by_offset(disp, _gloffset_%s, fn);' % (f.name)
+-            print '}'
+-            print
++            print('typedef %s (GLAPIENTRYP _glptr_%s)(%s);' % (f.return_type, f.name, arg_string))
++            print('#define CALL_%s(disp, parameters) \\' % (f.name))
++            print('    (* GET_%s(disp)) parameters' % (f.name))
++            print('static inline _glptr_%s GET_%s(struct _glapi_table *disp) {' % (f.name, f.name))
++            print('   return (_glptr_%s) (GET_by_offset(disp, _gloffset_%s));' % (f.name, f.name))
++            print('}')
++            print()
++            print('static inline void SET_%s(struct _glapi_table *disp, %s (GLAPIENTRYP fn)(%s)) {' % (f.name, f.return_type, arg_string))
++            print('   SET_by_offset(disp, _gloffset_%s, fn);' % (f.name))
++            print('}')
++            print()
+ 
+         return
+ 
+--- ./src/mapi/glapi/gen/gl_x86-64_asm.py	(original)
++++ ./src/mapi/glapi/gen/gl_x86-64_asm.py	(refactored)
+@@ -54,7 +54,7 @@
+     adjust_stack = 0
+     if not should_use_push(registers):
+         adjust_stack = local_size(registers)
+-        print '\tsubq\t$%u, %%rsp' % (adjust_stack)
++        print('\tsubq\t$%u, %%rsp' % (adjust_stack))
+ 
+     for [reg, stack_offset] in registers:
+         save_reg( reg, stack_offset, adjust_stack )
+@@ -72,18 +72,18 @@
+         restore_reg(reg, stack_offset, adjust_stack)
+ 
+     if adjust_stack:
+-        print '\taddq\t$%u, %%rsp' % (adjust_stack)
++        print('\taddq\t$%u, %%rsp' % (adjust_stack))
+     return
+ 
+ 
+ def save_reg(reg, offset, use_move):
+     if use_move:
+         if offset == 0:
+-            print '\tmovq\t%s, (%%rsp)' % (reg)
++            print('\tmovq\t%s, (%%rsp)' % (reg))
+         else:
+-            print '\tmovq\t%s, %u(%%rsp)' % (reg, offset)
++            print('\tmovq\t%s, %u(%%rsp)' % (reg, offset))
+     else:
+-        print '\tpushq\t%s' % (reg)
++        print('\tpushq\t%s' % (reg))
+ 
+     return
+ 
+@@ -91,11 +91,11 @@
+ def restore_reg(reg, offset, use_move):
+     if use_move:
+         if offset == 0:
+-            print '\tmovq\t(%%rsp), %s' % (reg)
++            print('\tmovq\t(%%rsp), %s' % (reg))
+         else:
+-            print '\tmovq\t%u(%%rsp), %s' % (offset, reg)
++            print('\tmovq\t%u(%%rsp), %s' % (offset, reg))
+     else:
+-        print '\tpopq\t%s' % (reg)
++        print('\tpopq\t%s' % (reg))
+ 
+     return
+ 
+@@ -119,63 +119,63 @@
+ 
+ 
+     def printRealHeader(self):
+-        print "/* If we build with gcc's -fvisibility=hidden flag, we'll need to change"
+-        print " * the symbol visibility mode to 'default'."
+-        print ' */'
+-        print ''
+-        print '#include "x86/assyntax.h"'
+-        print ''
+-        print '#ifdef __GNUC__'
+-        print '#  pragma GCC visibility push(default)'
+-        print '#  define HIDDEN(x) .hidden x'
+-        print '#else'
+-        print '#  define HIDDEN(x)'
+-        print '#endif'
+-        print ''
+-        print '# if defined(USE_MGL_NAMESPACE)'
+-        print '#  define GL_PREFIX(n) GLNAME(CONCAT(mgl,n))'
+-        print '#  define _glapi_Dispatch _mglapi_Dispatch'
+-        print '#  define _gl_DispatchTSD _mgl_DispatchTSD'
+-        print '# else'
+-        print '#  define GL_PREFIX(n) GLNAME(CONCAT(gl,n))'
+-        print '# endif'
+-        print ''
+-        print '\t.text'
+-        print ''
+-        print '#ifdef GLX_USE_TLS'
+-        print ''
+-        print '_x86_64_get_dispatch:'
+-        print '\tmovq\t_glapi_tls_Dispatch@GOTTPOFF(%rip), %rax'
+-        print '\tmovq\t%fs:(%rax), %rax'
+-        print '\tret'
+-        print '\t.size\t_x86_64_get_dispatch, .-_x86_64_get_dispatch'
+-        print ''
+-        print '#elif defined(HAVE_PTHREAD)'
+-        print ''
+-        print '\t.extern\t_glapi_Dispatch'
+-        print '\t.extern\t_gl_DispatchTSD'
+-        print '\t.extern\tpthread_getspecific'
+-        print ''
+-        print '\t.p2align\t4,,15'
+-        print '_x86_64_get_dispatch:'
+-        print '\tmovq\t_gl_DispatchTSD@GOTPCREL(%rip), %rax'
+-        print '\tmovl\t(%rax), %edi'
+-        print '\tjmp\tpthread_getspecific@PLT'
+-        print ''
+-        print '#else'
+-        print ''
+-        print '\t.extern\t_glapi_get_dispatch'
+-        print ''
+-        print '#endif'
+-        print ''
++        print("/* If we build with gcc's -fvisibility=hidden flag, we'll need to change")
++        print(" * the symbol visibility mode to 'default'.")
++        print(' */')
++        print('')
++        print('#include "x86/assyntax.h"')
++        print('')
++        print('#ifdef __GNUC__')
++        print('#  pragma GCC visibility push(default)')
++        print('#  define HIDDEN(x) .hidden x')
++        print('#else')
++        print('#  define HIDDEN(x)')
++        print('#endif')
++        print('')
++        print('# if defined(USE_MGL_NAMESPACE)')
++        print('#  define GL_PREFIX(n) GLNAME(CONCAT(mgl,n))')
++        print('#  define _glapi_Dispatch _mglapi_Dispatch')
++        print('#  define _gl_DispatchTSD _mgl_DispatchTSD')
++        print('# else')
++        print('#  define GL_PREFIX(n) GLNAME(CONCAT(gl,n))')
++        print('# endif')
++        print('')
++        print('\t.text')
++        print('')
++        print('#ifdef GLX_USE_TLS')
++        print('')
++        print('_x86_64_get_dispatch:')
++        print('\tmovq\t_glapi_tls_Dispatch@GOTTPOFF(%rip), %rax')
++        print('\tmovq\t%fs:(%rax), %rax')
++        print('\tret')
++        print('\t.size\t_x86_64_get_dispatch, .-_x86_64_get_dispatch')
++        print('')
++        print('#elif defined(HAVE_PTHREAD)')
++        print('')
++        print('\t.extern\t_glapi_Dispatch')
++        print('\t.extern\t_gl_DispatchTSD')
++        print('\t.extern\tpthread_getspecific')
++        print('')
++        print('\t.p2align\t4,,15')
++        print('_x86_64_get_dispatch:')
++        print('\tmovq\t_gl_DispatchTSD@GOTPCREL(%rip), %rax')
++        print('\tmovl\t(%rax), %edi')
++        print('\tjmp\tpthread_getspecific@PLT')
++        print('')
++        print('#else')
++        print('')
++        print('\t.extern\t_glapi_get_dispatch')
++        print('')
++        print('#endif')
++        print('')
+         return
+ 
+ 
+     def printRealFooter(self):
+-        print ''
+-        print '#if defined (__ELF__) && defined (__linux__)'
+-        print '	.section .note.GNU-stack,"",%progbits'
+-        print '#endif'
++        print('')
++        print('#if defined (__ELF__) && defined (__linux__)')
++        print('	.section .note.GNU-stack,"",%progbits')
++        print('#endif')
+         return
+ 
+ 
+@@ -220,47 +220,47 @@
+ 
+         name = f.dispatch_name()
+ 
+-        print '\t.p2align\t4,,15'
+-        print '\t.globl\tGL_PREFIX(%s)' % (name)
+-        print '\t.type\tGL_PREFIX(%s), @function' % (name)
++        print('\t.p2align\t4,,15')
++        print('\t.globl\tGL_PREFIX(%s)' % (name))
++        print('\t.type\tGL_PREFIX(%s), @function' % (name))
+         if not f.is_static_entry_point(f.name):
+-            print '\tHIDDEN(GL_PREFIX(%s))' % (name)
+-        print 'GL_PREFIX(%s):' % (name)
+-        print '#if defined(GLX_USE_TLS)'
+-        print '\tcall\t_x86_64_get_dispatch@PLT'
+-        print '\tmovq\t%u(%%rax), %%r11' % (f.offset * 8)
+-        print '\tjmp\t*%r11'
+-        print '#elif defined(HAVE_PTHREAD)'
++            print('\tHIDDEN(GL_PREFIX(%s))' % (name))
++        print('GL_PREFIX(%s):' % (name))
++        print('#if defined(GLX_USE_TLS)')
++        print('\tcall\t_x86_64_get_dispatch@PLT')
++        print('\tmovq\t%u(%%rax), %%r11' % (f.offset * 8))
++        print('\tjmp\t*%r11')
++        print('#elif defined(HAVE_PTHREAD)')
+ 
+         save_all_regs(registers)
+-        print '\tcall\t_x86_64_get_dispatch@PLT'
++        print('\tcall\t_x86_64_get_dispatch@PLT')
+         restore_all_regs(registers)
+ 
+         if f.offset == 0:
+-            print '\tmovq\t(%rax), %r11'
++            print('\tmovq\t(%rax), %r11')
+         else:
+-            print '\tmovq\t%u(%%rax), %%r11' % (f.offset * 8)
+-
+-        print '\tjmp\t*%r11'
+-
+-        print '#else'
+-        print '\tmovq\t_glapi_Dispatch(%rip), %rax'
+-        print '\ttestq\t%rax, %rax'
+-        print '\tje\t1f'
+-        print '\tmovq\t%u(%%rax), %%r11' % (f.offset * 8)
+-        print '\tjmp\t*%r11'
+-        print '1:'
++            print('\tmovq\t%u(%%rax), %%r11' % (f.offset * 8))
++
++        print('\tjmp\t*%r11')
++
++        print('#else')
++        print('\tmovq\t_glapi_Dispatch(%rip), %rax')
++        print('\ttestq\t%rax, %rax')
++        print('\tje\t1f')
++        print('\tmovq\t%u(%%rax), %%r11' % (f.offset * 8))
++        print('\tjmp\t*%r11')
++        print('1:')
+ 
+         save_all_regs(registers)
+-        print '\tcall\t_glapi_get_dispatch'
++        print('\tcall\t_glapi_get_dispatch')
+         restore_all_regs(registers)
+ 
+-        print '\tmovq\t%u(%%rax), %%r11' % (f.offset * 8)
+-        print '\tjmp\t*%r11'
+-        print '#endif /* defined(GLX_USE_TLS) */'
+-
+-        print '\t.size\tGL_PREFIX(%s), .-GL_PREFIX(%s)' % (name, name)
+-        print ''
++        print('\tmovq\t%u(%%rax), %%r11' % (f.offset * 8))
++        print('\tjmp\t*%r11')
++        print('#endif /* defined(GLX_USE_TLS) */')
++
++        print('\t.size\tGL_PREFIX(%s), .-GL_PREFIX(%s)' % (name, name))
++        print('')
+         return
+ 
+ 
+@@ -277,11 +277,11 @@
+                         text = '\t.globl GL_PREFIX(%s) ; .set GL_PREFIX(%s), GL_PREFIX(%s)' % (n, n, dispatch)
+ 
+                         if f.has_different_protocol(n):
+-                            print '#ifndef GLX_INDIRECT_RENDERING'
+-                            print text
+-                            print '#endif'
++                            print('#ifndef GLX_INDIRECT_RENDERING')
++                            print(text)
++                            print('#endif')
+                         else:
+-                            print text
++                            print(text)
+ 
+         return
+ 
+--- ./src/mapi/glapi/gen/gl_x86_asm.py	(original)
++++ ./src/mapi/glapi/gen/gl_x86_asm.py	(refactored)
+@@ -53,136 +53,136 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include "x86/assyntax.h"'
+-        print ''
+-        print '#if defined(STDCALL_API)'
+-        print '# if defined(USE_MGL_NAMESPACE)'
+-        print '#  define GL_PREFIX(n,n2) GLNAME(CONCAT(mgl,n2))'
+-        print '# else'
+-        print '#  define GL_PREFIX(n,n2) GLNAME(CONCAT(gl,n2))'
+-        print '# endif'
+-        print '#else'
+-        print '# if defined(USE_MGL_NAMESPACE)'
+-        print '#  define GL_PREFIX(n,n2) GLNAME(CONCAT(mgl,n))'
+-        print '#  define _glapi_Dispatch _mglapi_Dispatch'
+-        print '#  define _gl_DispatchTSD _mgl_DispatchTSD'
+-        print '# else'
+-        print '#  define GL_PREFIX(n,n2) GLNAME(CONCAT(gl,n))'
+-        print '# endif'
+-        print '#endif'
+-        print ''
+-        print '#define GL_OFFSET(x) CODEPTR(REGOFF(4 * x, EAX))'
+-        print ''
+-        print '#if defined(GNU_ASSEMBLER) && !defined(__MINGW32__) && !defined(__APPLE__)'
+-        print '#define GLOBL_FN(x) GLOBL x ; .type x, @function'
+-        print '#else'
+-        print '#define GLOBL_FN(x) GLOBL x'
+-        print '#endif'
+-        print ''
+-        print ''
+-        print '#ifdef GLX_USE_TLS'
+-        print ''
+-        print '#ifdef GLX_X86_READONLY_TEXT'
+-        print '# define CTX_INSNS MOV_L(GS:(EAX), EAX)'
+-        print '#else'
+-        print '# define CTX_INSNS NOP /* Pad for init_glapi_relocs() */'
+-        print '#endif'
+-        print ''
+-        print '#  define GL_STUB(fn,off,fn_alt)\t\t\t\\'
+-        print 'ALIGNTEXT16;\t\t\t\t\t\t\\'
+-        print 'GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\'
+-        print 'GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\'
+-        print '\tCALL(_x86_get_dispatch) ;\t\t\t\\'
+-        print '\tCTX_INSNS ;					\\'
+-        print '\tJMP(GL_OFFSET(off))'
+-        print ''
+-        print '#elif defined(HAVE_PTHREAD)'
+-        print '#  define GL_STUB(fn,off,fn_alt)\t\t\t\\'
+-        print 'ALIGNTEXT16;\t\t\t\t\t\t\\'
+-        print 'GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\'
+-        print 'GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\'
+-        print '\tMOV_L(CONTENT(GLNAME(_glapi_Dispatch)), EAX) ;\t\\'
+-        print '\tTEST_L(EAX, EAX) ;\t\t\t\t\\'
+-        print '\tJE(1f) ;\t\t\t\t\t\\'
+-        print '\tJMP(GL_OFFSET(off)) ;\t\t\t\t\\'
+-        print '1:\tCALL(_x86_get_dispatch) ;\t\t\t\\'
+-        print '\tJMP(GL_OFFSET(off))'
+-        print '#else'
+-        print '#  define GL_STUB(fn,off,fn_alt)\t\t\t\\'
+-        print 'ALIGNTEXT16;\t\t\t\t\t\t\\'
+-        print 'GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\'
+-        print 'GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\'
+-        print '\tMOV_L(CONTENT(GLNAME(_glapi_Dispatch)), EAX) ;\t\\'
+-        print '\tTEST_L(EAX, EAX) ;\t\t\t\t\\'
+-        print '\tJE(1f) ;\t\t\t\t\t\\'
+-        print '\tJMP(GL_OFFSET(off)) ;\t\t\t\t\\'
+-        print '1:\tCALL(_glapi_get_dispatch) ;\t\t\t\\'
+-        print '\tJMP(GL_OFFSET(off))'
+-        print '#endif'
+-        print ''
+-        print '#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS'
+-        print '#  define GL_STUB_ALIAS(fn,off,fn_alt,alias,alias_alt)\t\\'
+-        print '\t.globl\tGL_PREFIX(fn, fn_alt) ;\t\t\t\\'
+-        print '\t.set\tGL_PREFIX(fn, fn_alt), GL_PREFIX(alias, alias_alt)'
+-        print '#else'
+-        print '#  define GL_STUB_ALIAS(fn,off,fn_alt,alias,alias_alt)\t\\'
+-        print '    GL_STUB(fn, off, fn_alt)'
+-        print '#endif'
+-        print ''
+-        print 'SEG_TEXT'
+-        print ''
+-        print '#ifdef GLX_USE_TLS'
+-        print ''
+-        print '\tGLOBL\tGLNAME(_x86_get_dispatch)'
+-        print '\tHIDDEN(GLNAME(_x86_get_dispatch))'
+-        print 'ALIGNTEXT16'
+-        print 'GLNAME(_x86_get_dispatch):'
+-        print '\tcall	1f'
+-        print '1:\tpopl	%eax'
+-        print '\taddl	$_GLOBAL_OFFSET_TABLE_+[.-1b], %eax'
+-        print '\tmovl	_glapi_tls_Dispatch@GOTNTPOFF(%eax), %eax'
+-        print '\tret'
+-        print ''
+-        print '#elif defined(HAVE_PTHREAD)'
+-        print 'EXTERN GLNAME(_glapi_Dispatch)'
+-        print 'EXTERN GLNAME(_gl_DispatchTSD)'
+-        print 'EXTERN GLNAME(pthread_getspecific)'
+-        print ''
+-        print 'ALIGNTEXT16'
+-        print 'GLNAME(_x86_get_dispatch):'
+-        print '\tSUB_L(CONST(24), ESP)'
+-        print '\tPUSH_L(GLNAME(_gl_DispatchTSD))'
+-        print '\tCALL(GLNAME(pthread_getspecific))'
+-        print '\tADD_L(CONST(28), ESP)'
+-        print '\tRET'
+-        print '#else'
+-        print 'EXTERN GLNAME(_glapi_get_dispatch)'
+-        print '#endif'
+-        print ''
+-
+-        print '#if defined( GLX_USE_TLS ) && !defined( GLX_X86_READONLY_TEXT )'
+-        print '\t\t.section\twtext, "awx", @progbits'
+-        print '#endif /* defined( GLX_USE_TLS ) */'
+-
+-        print ''
+-        print '\t\tALIGNTEXT16'
+-        print '\t\tGLOBL GLNAME(gl_dispatch_functions_start)'
+-        print '\t\tHIDDEN(GLNAME(gl_dispatch_functions_start))'
+-        print 'GLNAME(gl_dispatch_functions_start):'
+-        print ''
++        print('#include "x86/assyntax.h"')
++        print('')
++        print('#if defined(STDCALL_API)')
++        print('# if defined(USE_MGL_NAMESPACE)')
++        print('#  define GL_PREFIX(n,n2) GLNAME(CONCAT(mgl,n2))')
++        print('# else')
++        print('#  define GL_PREFIX(n,n2) GLNAME(CONCAT(gl,n2))')
++        print('# endif')
++        print('#else')
++        print('# if defined(USE_MGL_NAMESPACE)')
++        print('#  define GL_PREFIX(n,n2) GLNAME(CONCAT(mgl,n))')
++        print('#  define _glapi_Dispatch _mglapi_Dispatch')
++        print('#  define _gl_DispatchTSD _mgl_DispatchTSD')
++        print('# else')
++        print('#  define GL_PREFIX(n,n2) GLNAME(CONCAT(gl,n))')
++        print('# endif')
++        print('#endif')
++        print('')
++        print('#define GL_OFFSET(x) CODEPTR(REGOFF(4 * x, EAX))')
++        print('')
++        print('#if defined(GNU_ASSEMBLER) && !defined(__MINGW32__) && !defined(__APPLE__)')
++        print('#define GLOBL_FN(x) GLOBL x ; .type x, @function')
++        print('#else')
++        print('#define GLOBL_FN(x) GLOBL x')
++        print('#endif')
++        print('')
++        print('')
++        print('#ifdef GLX_USE_TLS')
++        print('')
++        print('#ifdef GLX_X86_READONLY_TEXT')
++        print('# define CTX_INSNS MOV_L(GS:(EAX), EAX)')
++        print('#else')
++        print('# define CTX_INSNS NOP /* Pad for init_glapi_relocs() */')
++        print('#endif')
++        print('')
++        print('#  define GL_STUB(fn,off,fn_alt)\t\t\t\\')
++        print('ALIGNTEXT16;\t\t\t\t\t\t\\')
++        print('GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\')
++        print('GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\')
++        print('\tCALL(_x86_get_dispatch) ;\t\t\t\\')
++        print('\tCTX_INSNS ;					\\')
++        print('\tJMP(GL_OFFSET(off))')
++        print('')
++        print('#elif defined(HAVE_PTHREAD)')
++        print('#  define GL_STUB(fn,off,fn_alt)\t\t\t\\')
++        print('ALIGNTEXT16;\t\t\t\t\t\t\\')
++        print('GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\')
++        print('GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\')
++        print('\tMOV_L(CONTENT(GLNAME(_glapi_Dispatch)), EAX) ;\t\\')
++        print('\tTEST_L(EAX, EAX) ;\t\t\t\t\\')
++        print('\tJE(1f) ;\t\t\t\t\t\\')
++        print('\tJMP(GL_OFFSET(off)) ;\t\t\t\t\\')
++        print('1:\tCALL(_x86_get_dispatch) ;\t\t\t\\')
++        print('\tJMP(GL_OFFSET(off))')
++        print('#else')
++        print('#  define GL_STUB(fn,off,fn_alt)\t\t\t\\')
++        print('ALIGNTEXT16;\t\t\t\t\t\t\\')
++        print('GLOBL_FN(GL_PREFIX(fn, fn_alt));\t\t\t\\')
++        print('GL_PREFIX(fn, fn_alt):\t\t\t\t\t\\')
++        print('\tMOV_L(CONTENT(GLNAME(_glapi_Dispatch)), EAX) ;\t\\')
++        print('\tTEST_L(EAX, EAX) ;\t\t\t\t\\')
++        print('\tJE(1f) ;\t\t\t\t\t\\')
++        print('\tJMP(GL_OFFSET(off)) ;\t\t\t\t\\')
++        print('1:\tCALL(_glapi_get_dispatch) ;\t\t\t\\')
++        print('\tJMP(GL_OFFSET(off))')
++        print('#endif')
++        print('')
++        print('#ifdef HAVE_FUNC_ATTRIBUTE_ALIAS')
++        print('#  define GL_STUB_ALIAS(fn,off,fn_alt,alias,alias_alt)\t\\')
++        print('\t.globl\tGL_PREFIX(fn, fn_alt) ;\t\t\t\\')
++        print('\t.set\tGL_PREFIX(fn, fn_alt), GL_PREFIX(alias, alias_alt)')
++        print('#else')
++        print('#  define GL_STUB_ALIAS(fn,off,fn_alt,alias,alias_alt)\t\\')
++        print('    GL_STUB(fn, off, fn_alt)')
++        print('#endif')
++        print('')
++        print('SEG_TEXT')
++        print('')
++        print('#ifdef GLX_USE_TLS')
++        print('')
++        print('\tGLOBL\tGLNAME(_x86_get_dispatch)')
++        print('\tHIDDEN(GLNAME(_x86_get_dispatch))')
++        print('ALIGNTEXT16')
++        print('GLNAME(_x86_get_dispatch):')
++        print('\tcall	1f')
++        print('1:\tpopl	%eax')
++        print('\taddl	$_GLOBAL_OFFSET_TABLE_+[.-1b], %eax')
++        print('\tmovl	_glapi_tls_Dispatch@GOTNTPOFF(%eax), %eax')
++        print('\tret')
++        print('')
++        print('#elif defined(HAVE_PTHREAD)')
++        print('EXTERN GLNAME(_glapi_Dispatch)')
++        print('EXTERN GLNAME(_gl_DispatchTSD)')
++        print('EXTERN GLNAME(pthread_getspecific)')
++        print('')
++        print('ALIGNTEXT16')
++        print('GLNAME(_x86_get_dispatch):')
++        print('\tSUB_L(CONST(24), ESP)')
++        print('\tPUSH_L(GLNAME(_gl_DispatchTSD))')
++        print('\tCALL(GLNAME(pthread_getspecific))')
++        print('\tADD_L(CONST(28), ESP)')
++        print('\tRET')
++        print('#else')
++        print('EXTERN GLNAME(_glapi_get_dispatch)')
++        print('#endif')
++        print('')
++
++        print('#if defined( GLX_USE_TLS ) && !defined( GLX_X86_READONLY_TEXT )')
++        print('\t\t.section\twtext, "awx", @progbits')
++        print('#endif /* defined( GLX_USE_TLS ) */')
++
++        print('')
++        print('\t\tALIGNTEXT16')
++        print('\t\tGLOBL GLNAME(gl_dispatch_functions_start)')
++        print('\t\tHIDDEN(GLNAME(gl_dispatch_functions_start))')
++        print('GLNAME(gl_dispatch_functions_start):')
++        print('')
+         return
+ 
+ 
+     def printRealFooter(self):
+-        print ''
+-        print '\t\tGLOBL\tGLNAME(gl_dispatch_functions_end)'
+-        print '\t\tHIDDEN(GLNAME(gl_dispatch_functions_end))'
+-        print '\t\tALIGNTEXT16'
+-        print 'GLNAME(gl_dispatch_functions_end):'
+-        print ''
+-        print '#if defined (__ELF__) && defined (__linux__)'
+-        print '	.section .note.GNU-stack,"",%progbits'
+-        print '#endif'
++        print('')
++        print('\t\tGLOBL\tGLNAME(gl_dispatch_functions_end)')
++        print('\t\tHIDDEN(GLNAME(gl_dispatch_functions_end))')
++        print('\t\tALIGNTEXT16')
++        print('GLNAME(gl_dispatch_functions_end):')
++        print('')
++        print('#if defined (__ELF__) && defined (__linux__)')
++        print('	.section .note.GNU-stack,"",%progbits')
++        print('#endif')
+         return
+ 
+ 
+@@ -192,10 +192,10 @@
+             stack = self.get_stack_size(f)
+             alt = "%s@%u" % (name, stack)
+ 
+-            print '\tGL_STUB(%s, %d, %s)' % (name, f.offset, alt)
++            print('\tGL_STUB(%s, %d, %s)' % (name, f.offset, alt))
+ 
+             if not f.is_static_entry_point(f.name):
+-                print '\tHIDDEN(GL_PREFIX(%s, %s))' % (name, alt)
++                print('\tHIDDEN(GL_PREFIX(%s, %s))' % (name, alt))
+ 
+ 
+         for f in api.functionIterateByOffset():
+@@ -210,11 +210,11 @@
+                         text = '\tGL_STUB_ALIAS(%s, %d, %s, %s, %s)' % (n, f.offset, alt2, name, alt)
+ 
+                         if f.has_different_protocol(n):
+-                            print '#ifndef GLX_INDIRECT_RENDERING'
+-                            print text
+-                            print '#endif'
++                            print('#ifndef GLX_INDIRECT_RENDERING')
++                            print(text)
++                            print('#endif')
+                         else:
+-                            print text
++                            print(text)
+ 
+         return
+ 
+--- ./src/mapi/glapi/gen/remap_helper.py	(original)
++++ ./src/mapi/glapi/gen/remap_helper.py	(refactored)
+@@ -66,23 +66,23 @@
+ 
+ 
+     def printRealHeader(self):
+-        print '#include "main/dispatch.h"'
+-        print '#include "main/remap.h"'
+-        print ''
++        print('#include "main/dispatch.h"')
++        print('#include "main/remap.h"')
++        print('')
+         return
+ 
+ 
+     def printBody(self, api):
+         pool_indices = {}
+ 
+-        print '/* this is internal to remap.c */'
+-        print '#ifndef need_MESA_remap_table'
+-        print '#error Only remap.c should include this file!'
+-        print '#endif /* need_MESA_remap_table */'
+-        print ''
++        print('/* this is internal to remap.c */')
++        print('#ifndef need_MESA_remap_table')
++        print('#error Only remap.c should include this file!')
++        print('#endif /* need_MESA_remap_table */')
++        print('')
+ 
+-        print ''
+-        print 'static const char _mesa_function_pool[] ='
++        print('')
++        print('static const char _mesa_function_pool[] =')
+ 
+         # output string pool
+         index = 0;
+@@ -100,26 +100,26 @@
+             else:
+                 comments = "dynamic"
+ 
+-            print '   /* _mesa_function_pool[%d]: %s (%s) */' \
+-                            % (index, f.name, comments)
++            print('   /* _mesa_function_pool[%d]: %s (%s) */' \
++                            % (index, f.name, comments))
+             for line in spec:
+-                print '   "%s\\0"' % line
++                print('   "%s\\0"' % line)
+                 index += len(line) + 1
+-        print '   ;'
+-        print ''
++        print('   ;')
++        print('')
+ 
+-        print '/* these functions need to be remapped */'
+-        print 'static const struct gl_function_pool_remap MESA_remap_table_functions[] = {'
++        print('/* these functions need to be remapped */')
++        print('static const struct gl_function_pool_remap MESA_remap_table_functions[] = {')
+         # output all functions that need to be remapped
+         # iterate by offsets so that they are sorted by remap indices
+         for f in api.functionIterateByOffset():
+             if not f.assign_offset:
+                 continue
+-            print '   { %5d, %s_remap_index },' \
+-                            % (pool_indices[f], f.name)
+-        print '   {    -1, -1 }'
+-        print '};'
+-        print ''
++            print('   { %5d, %s_remap_index },' \
++                            % (pool_indices[f], f.name))
++        print('   {    -1, -1 }')
++        print('};')
++        print('')
+         return
+ 
+ 
+--- ./src/mapi/glapi/gen/typeexpr.py	(original)
++++ ./src/mapi/glapi/gen/typeexpr.py	(refactored)
+@@ -286,6 +286,6 @@
+     create_initial_types()
+ 
+     for t in types_to_try:
+-        print 'Trying "%s"...' % (t)
++        print('Trying "%s"...' % (t))
+         te = type_expression( t )
+-        print 'Got "%s" (%u, %u).' % (te.string(), te.get_stack_size(), te.get_element_size())
++        print('Got "%s" (%u, %u).' % (te.string(), te.get_stack_size(), te.get_element_size()))
+--- ./src/mesa/drivers/dri/common/xmlpool/gen_xmlpool.py	(original)
++++ ./src/mesa/drivers/dri/common/xmlpool/gen_xmlpool.py	(refactored)
+@@ -35,12 +35,12 @@
+         if s[i] == '"':
+             if i == len(s)-1 or s[i+1].isspace():
+                 # close quote
+-                q = u'\u201c'
++                q = '\u201c'
+             else:
+                 # open quote
+-                q = u'\u201d'
++                q = '\u201d'
+             r = r + q
+-        elif escapeSeqs.has_key(s[i]):
++        elif s[i] in escapeSeqs:
+             r = r + escapeSeqs[s[i]]
+         else:
+             r = r + s[i]
+@@ -88,7 +88,7 @@
+                 escape = False
+                 r = r + chr(num)
+         else:
+-            if escapeSeqs.has_key(s[i]):
++            if s[i] in escapeSeqs:
+                 r = r + escapeSeqs[s[i]]
+                 escape = False
+             elif s[i] >= '0' and s[i] <= '7':
+@@ -128,18 +128,18 @@
+             suffix = ' \\'
+         # Expand the description line. Need to use ugettext in order to allow
+         # non-ascii unicode chars in the original English descriptions.
+-        text = escapeCString (trans.ugettext (unicode (expandCString (
++        text = escapeCString (trans.ugettext (str (expandCString (
+             matches[0].expand (r'\5')), "utf-8"))).encode("utf-8")
+-        print matches[0].expand (r'\1' + lang + r'\3"' + text + r'"\7') + suffix
++        print(matches[0].expand (r'\1' + lang + r'\3"' + text + r'"\7') + suffix)
+         # Expand any subsequent enum lines
+         for match in matches[1:]:
+-            text = escapeCString (trans.ugettext (unicode (expandCString (
++            text = escapeCString (trans.ugettext (str (expandCString (
+                 match.expand (r'\3')), "utf-8"))).encode("utf-8")
+-            print match.expand (r'\1"' + text + r'"\5')
++            print(match.expand (r'\1"' + text + r'"\5'))
+ 
+         # Expand description end
+         if end:
+-            print end,
++            print(end, end=' ')
+ 
+ # Compile a list of translation classes to all supported languages.
+ # The first translation is always a NullTranslations.
+@@ -160,10 +160,9 @@
+ reDESC_END   = re.compile (r'\s*DRI_CONF_DESC_END')
+ 
+ # Print a header
+-print \
+-"/***********************************************************************\n" \
++print("/***********************************************************************\n" \
+ " ***        THIS FILE IS GENERATED AUTOMATICALLY. DON'T EDIT!        ***\n" \
+-" ***********************************************************************/"
++" ***********************************************************************/")
+ 
+ # Process the options template and generate options.h with all
+ # translations.
+@@ -185,7 +184,7 @@
+         continue
+     if reLibintl_h.search (line):
+         # Ignore (comment out) #include <libintl.h>
+-        print "/* %s * commented out by gen_xmlpool.py */" % line
++        print("/* %s * commented out by gen_xmlpool.py */" % line)
+         continue
+     matchDESC       = reDESC      .match (line)
+     matchDESC_BEGIN = reDESC_BEGIN.match (line)
+@@ -196,7 +195,7 @@
+         assert len(descMatches) == 0
+         descMatches = [matchDESC_BEGIN]
+     else:
+-        print line,
++        print(line, end=' ')
+ 
+ if len(descMatches) > 0:
+     sys.stderr.write ("Warning: unterminated description at end of file.\n")
+--- ./src/mesa/main/format_info.py	(original)
++++ ./src/mesa/main/format_info.py	(refactored)
+@@ -135,7 +135,7 @@
+ 
+ formats = parser.parse(sys.argv[1])
+ 
+-print '''
++print('''
+ /*
+  * Mesa 3-D graphics library
+  *
+@@ -167,32 +167,32 @@
+ 
+ static struct gl_format_info format_info[MESA_FORMAT_COUNT] =
+ {
+-'''
++''')
+ 
+ for fmat in formats:
+-   print '   {'
+-   print '      {0},'.format(fmat.name)
+-   print '      "{0}",'.format(fmat.name)
+-   print '      {0},'.format('MESA_FORMAT_LAYOUT_' + fmat.layout.upper())
+-   print '      {0},'.format(get_gl_base_format(fmat))
+-   print '      {0},'.format(get_gl_data_type(fmat))
++   print('   {')
++   print('      {0},'.format(fmat.name))
++   print('      "{0}",'.format(fmat.name))
++   print('      {0},'.format('MESA_FORMAT_LAYOUT_' + fmat.layout.upper()))
++   print('      {0},'.format(get_gl_base_format(fmat)))
++   print('      {0},'.format(get_gl_data_type(fmat)))
+ 
+    bits = [ get_channel_bits(fmat, name) for name in ['r', 'g', 'b', 'a']]
+-   print '      {0},'.format(', '.join(map(str, bits)))
++   print('      {0},'.format(', '.join(map(str, bits))))
+    bits = [ get_channel_bits(fmat, name) for name in ['l', 'i', 'z', 's']]
+-   print '      {0},'.format(', '.join(map(str, bits)))
+-
+-   print '      {0:d},'.format(fmat.colorspace == 'srgb')
+-
+-   print '      {0}, {1}, {2}, {3},'.format(fmat.block_width, fmat.block_height,
++   print('      {0},'.format(', '.join(map(str, bits))))
++
++   print('      {0:d},'.format(fmat.colorspace == 'srgb'))
++
++   print('      {0}, {1}, {2}, {3},'.format(fmat.block_width, fmat.block_height,
+                                             fmat.block_depth,
+-                                            int(fmat.block_size() / 8))
+-
+-   print '      {{ {0} }},'.format(', '.join(map(str, fmat.swizzle)))
++                                            int(fmat.block_size() / 8)))
++
++   print('      {{ {0} }},'.format(', '.join(map(str, fmat.swizzle))))
+    if fmat.is_array():
+       chan = fmat.array_element()
+       norm = chan.norm or chan.type == parser.FLOAT
+-      print '      MESA_ARRAY_FORMAT({0}),'.format(', '.join([
++      print('      MESA_ARRAY_FORMAT({0}),'.format(', '.join([
+          str(chan.size / 8),
+          str(int(chan.sign)),
+          str(int(chan.type == parser.FLOAT)),
+@@ -202,9 +202,9 @@
+          str(fmat.swizzle[1]),
+          str(fmat.swizzle[2]),
+          str(fmat.swizzle[3]),
+-      ]))
+-   else:
+-      print '      0,'
+-   print '   },'
+-
+-print '};'
++      ])))
++   else:
++      print('      0,')
++   print('   },')
++
++print('};')
+--- ./src/mesa/main/format_pack.py	(original)
++++ ./src/mesa/main/format_pack.py	(refactored)
+@@ -999,4 +999,4 @@
+ 
+ template = Template(string);
+ 
+-print template.render(argv = argv[0:])
++print(template.render(argv = argv[0:]))
+--- ./src/mesa/main/format_parser.py	(original)
++++ ./src/mesa/main/format_parser.py	(refactored)
+@@ -216,8 +216,8 @@
+       component, exactly as you would expect.
+       """
+       rev = [Swizzle.SWIZZLE_NONE] * 4
+-      for i in xrange(4):
+-         for j in xrange(4):
++      for i in range(4):
++         for j in range(4):
+             if self.__list[j] == i and rev[i] == Swizzle.SWIZZLE_NONE:
+                rev[i] = j
+       return Swizzle(rev)
+--- ./src/mesa/main/format_unpack.py	(original)
++++ ./src/mesa/main/format_unpack.py	(refactored)
+@@ -890,4 +890,4 @@
+ 
+ template = Template(string);
+ 
+-print template.render(argv = argv[0:])
++print(template.render(argv = argv[0:]))
+--- ./src/mesa/main/get_hash_generator.py	(original)
++++ ./src/mesa/main/get_hash_generator.py	(refactored)
+@@ -46,16 +46,16 @@
+ gl_apis=set(["GL", "GL_CORE", "GLES", "GLES2", "GLES3", "GLES31", "GLES32"])
+ 
+ def print_header():
+-   print "typedef const unsigned short table_t[%d];\n" % (hash_table_size)
+-   print "static const int prime_factor = %d, prime_step = %d;\n" % \
+-          (prime_factor, prime_step)
++   print("typedef const unsigned short table_t[%d];\n" % (hash_table_size))
++   print("static const int prime_factor = %d, prime_step = %d;\n" % \
++          (prime_factor, prime_step))
+ 
+ def print_params(params):
+-   print "static const struct value_desc values[] = {"
++   print("static const struct value_desc values[] = {")
+    for p in params:
+-      print "    { %s, %s }," % (p[0], p[1])
+-
+-   print "};\n"
++      print("    { %s, %s }," % (p[0], p[1]))
++
++   print("};\n")
+ 
+ def api_name(api):
+    return "API_OPEN%s" % api
+@@ -78,7 +78,7 @@
+    return "table_" + api_name(api)
+ 
+ def print_table(api, table):
+-   print "static table_t %s = {" % (table_name(api))
++   print("static table_t %s = {" % (table_name(api)))
+ 
+    # convert sparse (index, value) table into a dense table
+    dense_table = [0] * hash_table_size
+@@ -89,9 +89,9 @@
+    for i in range(0, hash_table_size, row_size):
+       row = dense_table[i : i + row_size]
+       idx_val = ["%4d" % v for v in row]
+-      print " " * 4 + ", ".join(idx_val) + ","
+-
+-   print "};\n"
++      print(" " * 4 + ", ".join(idx_val) + ",")
++
++   print("};\n")
+ 
+ def print_tables(tables):
+    for table in tables:
+@@ -104,19 +104,18 @@
+          i = api_index(api)
+          dense_tables[i] = "&%s" % (tname)
+ 
+-   print "static table_t *table_set[] = {"
++   print("static table_t *table_set[] = {")
+    for expr in dense_tables:
+-      print "   %s," % expr
+-   print "};\n"
+-
+-   print "#define table(api) (*table_set[api])"
++      print("   %s," % expr)
++   print("};\n")
++
++   print("#define table(api) (*table_set[api])")
+ 
+ # Merge tables with matching parameter lists (i.e. GL and GL_CORE)
+ def merge_tables(tables):
+    merged_tables = []
+    for api, indices in sorted(tables.items()):
+-      matching_table = filter(lambda mt:mt["indices"] == indices,
+-                              merged_tables)
++      matching_table = [mt for mt in merged_tables if mt["indices"] == indices]
+       if matching_table:
+          matching_table[0]["apis"].append(api)
+       else:
+@@ -183,7 +182,7 @@
+          params.append(["GL_" + enum_name, param[1]])
+ 
+    sorted_tables={}
+-   for api, indices in tables.items():
++   for api, indices in list(tables.items()):
+       sorted_tables[api] = sorted(indices.items())
+ 
+    return params, merge_tables(sorted_tables)
+@@ -199,7 +198,7 @@
+ if __name__ == '__main__':
+    try:
+       (opts, args) = getopt.getopt(sys.argv[1:], "f:")
+-   except Exception,e:
++   except Exception as e:
+       show_usage()
+ 
+    if len(args) != 0:
+--- ./src/util/format_srgb.py	(original)
++++ ./src/util/format_srgb.py	(refactored)
+@@ -57,33 +57,33 @@
+ 
+ 
+ def generate_srgb_tables():
+-    print 'const float'
+-    print 'util_format_srgb_8unorm_to_linear_float_table[256] = {'
++    print('const float')
++    print('util_format_srgb_8unorm_to_linear_float_table[256] = {')
+     for j in range(0, 256, 4):
+-        print '   ',
++        print('   ', end=' ')
+         for i in range(j, j + 4):
+-            print '%.7e,' % (srgb_to_linear(i / 255.0),),
+-        print
+-    print '};'
+-    print
+-    print 'const uint8_t'
+-    print 'util_format_srgb_to_linear_8unorm_table[256] = {'
++            print('%.7e,' % (srgb_to_linear(i / 255.0),), end=' ')
++        print()
++    print('};')
++    print()
++    print('const uint8_t')
++    print('util_format_srgb_to_linear_8unorm_table[256] = {')
+     for j in range(0, 256, 16):
+-        print '   ',
++        print('   ', end=' ')
+         for i in range(j, j + 16):
+-            print '%3u,' % (int(srgb_to_linear(i / 255.0) * 255.0 + 0.5),),
+-        print
+-    print '};'
+-    print
+-    print 'const uint8_t'
+-    print 'util_format_linear_to_srgb_8unorm_table[256] = {'
++            print('%3u,' % (int(srgb_to_linear(i / 255.0) * 255.0 + 0.5),), end=' ')
++        print()
++    print('};')
++    print()
++    print('const uint8_t')
++    print('util_format_linear_to_srgb_8unorm_table[256] = {')
+     for j in range(0, 256, 16):
+-        print '   ',
++        print('   ', end=' ')
+         for i in range(j, j + 16):
+-            print '%3u,' % (int(linear_to_srgb(i / 255.0) * 255.0 + 0.5),),
+-        print
+-    print '};'
+-    print
++            print('%3u,' % (int(linear_to_srgb(i / 255.0) * 255.0 + 0.5),), end=' ')
++        print()
++    print('};')
++    print()
+ 
+ # calculate the table interpolation values used in float linear to unorm8 srgb
+     numexp = 13
+@@ -128,25 +128,25 @@
+ 
+         valtable.append((int_a << 16) + int_b)
+ 
+-    print 'const unsigned'
+-    print 'util_format_linear_to_srgb_helper_table[104] = {'
++    print('const unsigned')
++    print('util_format_linear_to_srgb_helper_table[104] = {')
+ 
+     for j in range(0, nbuckets, 4):
+-        print '   ',
++        print('   ', end=' ')
+         for i in range(j, j + 4):
+-            print '0x%08x,' % (valtable[i],),
+-        print
+-    print '};'
+-    print
++            print('0x%08x,' % (valtable[i],), end=' ')
++        print()
++    print('};')
++    print()
+ 
+ def main():
+-    print '/* This file is autogenerated by u_format_srgb.py. Do not edit directly. */'
+-    print
++    print('/* This file is autogenerated by u_format_srgb.py. Do not edit directly. */')
++    print()
+     # This will print the copyright message on the top of this file
+-    print CopyRight.strip()
+-    print
+-    print '#include "format_srgb.h"'
+-    print
++    print(CopyRight.strip())
++    print()
++    print('#include "format_srgb.h"')
++    print()
+     generate_srgb_tables()
+ 
+ 


### PR DESCRIPTION
Note that python2+mako is still needed.

This is a **BIG** patch, maybe better to move to a newer Mesa? Anyway, these patches are needed to build osmesa on latest MSYS2/MinGW.

Also note that scons has been removed in later versions of Mesa (they now use meson).